### PR TITLE
Add support for default A2A agent card location and message/send

### DIFF
--- a/a2a-rs/src/adapter/transport/http/client.rs
+++ b/a2a-rs/src/adapter/transport/http/client.rs
@@ -8,6 +8,7 @@ use reqwest::{
     header::{HeaderMap, HeaderValue, CONTENT_TYPE},
     Client,
 };
+use serde_json::{Map, Value};
 use std::{pin::Pin, time::Duration};
 
 #[cfg(feature = "tracing")]
@@ -17,11 +18,11 @@ use crate::{
     adapter::error::HttpClientError,
     application::{
         json_rpc::{self, A2ARequest, SendTaskRequest},
-        JSONRPCResponse,
+        JSONRPCResponse, SendMessageRequest,
     },
     domain::{
-        A2AError, Message, Task, TaskIdParams, TaskPushNotificationConfig, TaskQueryParams,
-        TaskSendParams,
+        A2AError, Message, MessageSendConfiguration, MessageSendParams, Task, TaskIdParams,
+        TaskPushNotificationConfig, TaskQueryParams, TaskSendParams,
     },
     services::client::{AsyncA2AClient, StreamItem},
 };
@@ -282,6 +283,40 @@ impl AsyncA2AClient for HttpClient {
             Some(value) => {
                 let config: TaskPushNotificationConfig = serde_json::from_value(value)?;
                 Ok(config)
+            }
+            None => {
+                if let Some(error) = response.error {
+                    Err(A2AError::JsonRpc {
+                        code: error.code,
+                        message: error.message,
+                        data: error.data,
+                    })
+                } else {
+                    Err(A2AError::Internal("Empty response".to_string()))
+                }
+            }
+        }
+    }
+
+    async fn send_message<'a>(
+        &self,
+        message: &'a Message,
+        metadata: Option<&'a Map<String, Value>>,
+        configuration: Option<&'a MessageSendConfiguration>,
+    ) -> Result<Task, A2AError> {
+        let params = MessageSendParams {
+            message: message.clone(),
+            configuration: configuration.cloned(),
+            metadata: metadata.cloned(),
+        };
+
+        let request = SendMessageRequest::new(params);
+        let response = self.send_request(&A2ARequest::SendMessage(request)).await?;
+
+        match response.result {
+            Some(value) => {
+                let task: Task = serde_json::from_value(value)?;
+                Ok(task)
             }
             None => {
                 if let Some(error) = response.error {

--- a/a2a-rs/src/adapter/transport/http/server.rs
+++ b/a2a-rs/src/adapter/transport/http/server.rs
@@ -90,6 +90,7 @@ where
         let mut app = Router::new()
             .route("/", post(handle_request))
             .route("/agent-card", get(handle_agent_card))
+            .route("/.well-known/agent-card.json", get(handle_agent_card))
             .route("/skills", get(handle_skills))
             .route("/skills/{id}", get(handle_skill_by_id))
             .with_state(ServerState {

--- a/a2a-rs/src/application/handlers/message.rs
+++ b/a2a-rs/src/application/handlers/message.rs
@@ -43,6 +43,12 @@ impl SendTaskRequest {
             params,
         }
     }
+
+    #[must_use]
+    pub fn with_id(mut self, id: Option<Value>) -> Self {
+        self.id = id;
+        self
+    }
 }
 
 /// Response to a send message request
@@ -108,6 +114,12 @@ impl SendTaskStreamingRequest {
             method: "tasks/sendSubscribe".to_string(),
             params,
         }
+    }
+
+    #[must_use]
+    pub fn with_id(mut self, id: Option<Value>) -> Self {
+        self.id = id;
+        self
     }
 }
 

--- a/a2a-rs/src/services/client.rs
+++ b/a2a-rs/src/services/client.rs
@@ -2,13 +2,14 @@
 
 use async_trait::async_trait;
 use futures::Stream;
+use serde_json::{Map, Value};
 use std::pin::Pin;
 
 use crate::{
     application::{json_rpc::A2ARequest, JSONRPCResponse},
     domain::{
-        A2AError, Message, Task, TaskArtifactUpdateEvent, TaskPushNotificationConfig,
-        TaskStatusUpdateEvent,
+        A2AError, Message, MessageSendConfiguration, Task, TaskArtifactUpdateEvent,
+        TaskPushNotificationConfig, TaskStatusUpdateEvent,
     },
 };
 
@@ -28,6 +29,14 @@ pub trait AsyncA2AClient: Send + Sync {
         message: &'a Message,
         session_id: Option<&'a str>,
         history_length: Option<u32>,
+    ) -> Result<Task, A2AError>;
+
+    /// Send a message using the new message/send protocol
+    async fn send_message<'a>(
+        &self,
+        message: &'a Message,
+        metadata: Option<&'a Map<String, Value>>,
+        configuration: Option<&'a MessageSendConfiguration>,
     ) -> Result<Task, A2AError>;
 
     /// Get a task by ID


### PR DESCRIPTION
This PR introduces support for accept default location for A2A agent card and implements the "message/send" protocol for agent communication.