### PR TITLE
feat(http-server): expose HttpServer::build_router()

### DIFF
--- a/a2a-rs/src/adapter/transport/http/server.rs
+++ b/a2a-rs/src/adapter/transport/http/server.rs
@@ -71,15 +71,12 @@ where
         }
     }
 
-    /// Start the HTTP server
-    #[cfg_attr(feature = "tracing", instrument(skip(self), fields(
-        server.address = %self.address,
-        server.has_auth = self.authenticator.is_some()
-    )))]
-    pub async fn start(&self) -> Result<(), A2AError> {
-        #[cfg(feature = "tracing")]
-        info!("Starting HTTP server");
-
+    /// Build the Axum router that exposes the A2A protocol.
+    ///
+    /// **ingram-services fork addition**: extracted from `start()` so callers
+    /// that need a custom transport (e.g. mTLS via `axum-server` with rustls)
+    /// can mount the same routes on their own listener. Upstream PR pending.
+    pub fn build_router(&self) -> Router {
         let processor = self.processor.clone();
         let agent_info = self.agent_info.clone();
 
@@ -106,6 +103,20 @@ where
             // Create an auth router with the authenticator
             app = with_auth(app, (*auth_clone).clone());
         }
+
+        app
+    }
+
+    /// Start the HTTP server
+    #[cfg_attr(feature = "tracing", instrument(skip(self), fields(
+        server.address = %self.address,
+        server.has_auth = self.authenticator.is_some()
+    )))]
+    pub async fn start(&self) -> Result<(), A2AError> {
+        #[cfg(feature = "tracing")]
+        info!("Starting HTTP server");
+
+        let app = self.build_router();
 
         let listener = tokio::net::TcpListener::bind(&self.address)
             .await


### PR DESCRIPTION
## Summary

Extracts the Axum router construction from `HttpServer::start()` into a public `build_router() -> Router` method. `start()` becomes a thin wrapper that calls `build_router()` and serves it on a plain TCP listener — **no behavioural change for existing callers**.

## Motivation

Downstream users that want to run an A2A server behind a custom listener (e.g. mTLS via `axum-server` with rustls, or behind a tower-http stack) need a way to mount the router on their own server. Today `start()` builds and serves it inline with no escape hatch.

Exposing the router lets callers:
- inject a different `Listener` (e.g. `RustlsAcceptor` from `axum-server`),
- merge the router with their own routes,
- inspect or test the route set in isolation.

## Changes

- New `HttpServer::build_router(&self) -> Router` (the existing router-building code, lifted out of `start`).
- `start()` now calls `build_router()` and binds it on the configured address.

## Tests

The example `http_client_server` still passes; `start()` is byte-identical from the caller's point of view.

## Real-world usage

One of three small PRs from a multi-agent project (ingram-services) running `a2a-rs` over mTLS. Happy to iterate on naming / API shape if you prefer something different.