### PR TITLE
Add Antigravity IDE plugin for Rust patterns

### DIFF
--- a/.agents/plugins/rust-patterns/plugin.json
+++ b/.agents/plugins/rust-patterns/plugin.json
@@ -1,0 +1,3 @@
+{
+  "name": "rust-patterns"
+}

--- a/.agents/plugins/rust-patterns/rules/rust_best_practices.md
+++ b/.agents/plugins/rust-patterns/rules/rust_best_practices.md
@@ -1,0 +1,20 @@
+# Rust Best Practices
+
+When writing, reviewing, or refactoring Rust code, strictly adhere to these core rules derived from the Rust Patterns Book:
+
+1. **Avoid Code Bloat via Monomorphization**
+   - Be cautious of using generics on large functions that are instantiated with many types.
+   - Use the "outline" pattern: Extract the non-generic core logic into a separate function that the generic function calls to minimize the duplicated monomorphized code.
+
+2. **Prefer Static Dispatch (Generics/Enum Dispatch) over Dynamic Dispatch (`dyn Trait`)**
+   - Default to using generics (`impl Trait` or `<T: Trait>`) since they are monomorphized, have zero cost, and can be aggressively inlined by LLVM.
+   - For a closed, finite set of types, use Enum Dispatch (implementing the trait on an Enum with variants) to maintain static dispatch while collecting them in a homogeneous structure.
+
+3. **Use `dyn Trait` Only When Necessary**
+   - Use dynamic dispatch (e.g. `Box<dyn Trait>`) only when the set of types is open (e.g. plugin architectures), when you need heterogeneous collections of varied trait implementors, or on cold paths (like error logging) where binary size matters more than execution speed.
+
+4. **Embrace Type Safety and Domain Modeling**
+   - Use Newtypes (e.g., `struct UserId(u64)`) to enforce zero-cost compile-time boundaries between different domain concepts.
+   - For complex system modeling, rely on Associated Types and Marker Traits to encode type states and invariants directly into the type system, ensuring invalid states are unrepresentable and cause compile errors, not runtime panics.
+
+Source: https://microsoft.github.io/RustTraining/rust-patterns-book/

--- a/.agents/plugins/rust-patterns/rules/rust_best_practices.md
+++ b/.agents/plugins/rust-patterns/rules/rust_best_practices.md
@@ -13,8 +13,21 @@ When writing, reviewing, or refactoring Rust code, strictly adhere to these core
 3. **Use `dyn Trait` Only When Necessary**
    - Use dynamic dispatch (e.g. `Box<dyn Trait>`) only when the set of types is open (e.g. plugin architectures), when you need heterogeneous collections of varied trait implementors, or on cold paths (like error logging) where binary size matters more than execution speed.
 
-4. **Embrace Type Safety and Domain Modeling**
+4. **Embrace Type Safety and Domain Modeling (Parse, don't validate)**
    - Use Newtypes (e.g., `struct UserId(u64)`) to enforce zero-cost compile-time boundaries between different domain concepts.
+   - Parse untyped inputs (e.g., primitive integers or strings) at the boundary using `TryFrom` or `FromStr` into validated types, rather than passing raw types and validating them deep in the business logic.
    - For complex system modeling, rely on Associated Types and Marker Traits to encode type states and invariants directly into the type system, ensuring invalid states are unrepresentable and cause compile errors, not runtime panics.
+
+5. **Choose the Right Concurrency and Synchronization Tools**
+   - For simple message passing, use bounded channels (to create natural backpressure and prevent OOM).
+   - Use `std::thread::scope` for parallel processing that needs to borrow local stack variables safely. Use `rayon` for data-parallel collection processing.
+   - Prefer `std::sync::OnceLock` or `std::sync::LazyLock` for lazy initialization instead of older macros like `lazy_static!`.
+   - Use Mutexes for short critical sections, RwLocks for read-heavy shared data, and Atomics for simple flags or counters.
+   - For complex shared mutable state, strongly consider the Actor pattern using channels rather than scattering Mutexes.
+
+6. **Distinguish Error Handling by Context**
+   - Libraries must define strongly typed, exhaustive error enumerations using crates like `thiserror` to allow consumers to programmatically react to failures.
+   - Binaries and applications should favor the `anyhow` crate to propagate errors efficiently with `Result` and `.context("human readable context")`.
+   - Never use `panic!` or `unwrap()` for expected failures; reserve them strictly for unrecoverable programming bugs.
 
 Source: https://microsoft.github.io/RustTraining/rust-patterns-book/

--- a/.agents/plugins/rust-patterns/skills/architectural_review/SKILL.md
+++ b/.agents/plugins/rust-patterns/skills/architectural_review/SKILL.md
@@ -1,0 +1,25 @@
+# Architectural Review (Rust)
+
+This skill helps you perform an architectural review of Rust code based on advanced patterns found in the "Rust Patterns & Engineering How-Tos" guide.
+When asked to review system architecture or suggest broad improvements in a Rust project, apply these architectural patterns:
+https://microsoft.github.io/RustTraining/rust-patterns-book/
+
+## Capability Mixins (Composition over Inheritance)
+- Rust doesn't have class inheritance. Instead, use traits with associated types and default method implementations to compose behaviors.
+- Define "Ingredient" traits containing primitive operations (e.g. `HasBus { type Bus; fn bus(&self) -> &Self::Bus; }`).
+- Define "Mixin" traits that require ingredient traits as supertraits, and provide default implementations for domain logic (e.g. `trait FeatureMixin: HasBus`).
+- Use blanket implementations (`impl<T: HasBus> FeatureMixin for T {}`) so any type with the ingredient automatically gets the mixin behavior at compile time with zero overhead.
+
+## Typed Commands (GADT-style Return Types)
+- Avoid "Untyped Swamp" signatures where generic byte buffers (`Vec<u8>`) are passed around indiscriminately.
+- Create Domain Newtypes to represent physical/logical constraints strongly (e.g., `Celsius(f64)`, `Rpm(u32)`).
+- Use a Command Trait where the associated type dictates the specific return type of that command (e.g., `trait Command { type Response; }`).
+- When a command is executed, its concrete type ensures the correct return format is parsed and returned natively, turning unit-confusion runtime errors into compile-time errors.
+
+## General Design Feedback
+- Promote "Parse, don't validate". Use the type system to enforce invariants across API boundaries (e.g., using `NonEmptyVec` or `ValidatedEmail` types) instead of relying on checks inside functions.
+- Consider memory layouts and cache friendliness: suggest contiguous memory layouts and enum dispatch over pointer-chasing `Vec<Box<dyn Trait>>` when the set of variants is known and finite.
+
+## Implementation Details
+- During architectural review, look for places where untyped logic, massive enumerations, or poor trait configurations are causing friction or bugs.
+- Suggest how to incrementally migrate toward Mixins or Typed Commands.

--- a/.agents/plugins/rust-patterns/skills/architectural_review/SKILL.md
+++ b/.agents/plugins/rust-patterns/skills/architectural_review/SKILL.md
@@ -16,10 +16,26 @@ https://microsoft.github.io/RustTraining/rust-patterns-book/
 - Use a Command Trait where the associated type dictates the specific return type of that command (e.g., `trait Command { type Response; }`).
 - When a command is executed, its concrete type ensures the correct return format is parsed and returned natively, turning unit-confusion runtime errors into compile-time errors.
 
+## Concurrency and Parallelism
+- Understand the distinction between concurrency (tasks making progress) and parallelism (simultaneous execution).
+- **Threads vs. Rayon**: Use OS threads (`std::thread::spawn`) for long-running background tasks. Use `rayon::par_iter()` for data parallelism when processing collections. Use scoped threads (`std::thread::scope`) to safely borrow stack variables across short-lived parallel tasks.
+- **Shared State**: Use `Mutex<T>` for exclusive access in short critical sections. Use `RwLock<T>` for read-heavy workloads with rare writes. Use `AtomicU64` and similar atomic types for simple flags/counters to avoid lock overhead.
+- **Message Passing**: Prefer `crossbeam-channel` over `std::sync::mpsc` in production for multi-consumer support and select macros. Use bounded channels to implement backpressure and avoid OOM issues. Employ the Actor pattern with channels to encapsulate complex shared mutable state instead of wrapping everything in a Mutex.
+
+## Smart Pointers and Interior Mutability
+- **Heap vs Stack**: Use `Box<T>` for single ownership heap allocation, `Rc<T>` for single-threaded shared ownership, and `Arc<T>` for thread-safe shared ownership. Use `Weak<T>` to break reference cycles.
+- **Interior Mutability**: Use `Cell<T>` for `Copy` types, `RefCell<T>` for runtime borrow-checking within a single thread, and `Mutex<T>`/`RwLock<T>` for multi-threaded interior mutability.
+- Utilize `OnceLock` or `LazyLock` over deprecated macros like `lazy_static!`.
+
+## Error Handling Architecture
+- **Library vs Application**: For libraries, use `thiserror` to define precise, matching-friendly enum types so consumers can programmatically handle them. For applications, use `anyhow` for dynamic error reporting and simple `.context()` propagation.
+- Use `#[from]` inside `thiserror` enums to build effective error conversion chains.
+
 ## General Design Feedback
-- Promote "Parse, don't validate". Use the type system to enforce invariants across API boundaries (e.g., using `NonEmptyVec` or `ValidatedEmail` types) instead of relying on checks inside functions.
+- **Parse, don't validate**: Use the type system to enforce invariants across API boundaries (e.g., using `TryFrom` to parse an untyped input into a validated Newtype like `Port` or `ValidEmail`) instead of relying on runtime checks inside business logic functions.
 - Consider memory layouts and cache friendliness: suggest contiguous memory layouts and enum dispatch over pointer-chasing `Vec<Box<dyn Trait>>` when the set of variants is known and finite.
+- Utilize Zero-Copy deserialization with Serde (`&'a str` fields) for high-performance read-heavy parsing to avoid unnecessary heap allocations.
 
 ## Implementation Details
-- During architectural review, look for places where untyped logic, massive enumerations, or poor trait configurations are causing friction or bugs.
-- Suggest how to incrementally migrate toward Mixins or Typed Commands.
+- During architectural review, look for places where untyped logic, massive enumerations, excessive cloning, thread contention, or poor trait configurations are causing friction or bugs.
+- Suggest how to incrementally migrate toward Mixins, Typed Commands, or better concurrency models.

--- a/.agents/plugins/rust-patterns/skills/refactor_idiomatic_rust/SKILL.md
+++ b/.agents/plugins/rust-patterns/skills/refactor_idiomatic_rust/SKILL.md
@@ -16,6 +16,21 @@ https://microsoft.github.io/RustTraining/rust-patterns-book/
 - Use **Blanket Implementations** carefully but effectively (e.g. `impl<T: Display> ToString for T`) to give trait implementations for free to any type matching the constraints.
 - Maintain **Trait Object Safety Rules**: Traits meant for dynamic dispatch must not have `Self: Sized` bounds on methods meant for the vtable, no generic type parameters on methods, and no `Self` in return position (unless boxed).
 
+## Closures and Iterators
+- Use the weakest closure bound necessary: accept `FnMut` by default to be flexible for callers, require `Fn` only if called concurrently, and `FnOnce` if called exactly once.
+- Refactor imperative loops to functional combinator chains (e.g., `.iter().filter().map().collect()`) when operating on iterators.
+- Apply the **With Pattern** (bracketed resource access) for resources requiring guaranteed setup and teardown, passing a handle to a closure to ensure it doesn't escape the expected scope.
+
+## Error Handling
+- Use the `?` operator for clean error propagation. Remember it works by doing a `match`, `From::from(e)`, and early returning `Err`.
+- Avoid panicking in expected failure states. Return `Result` for expected errors (e.g. file IO or networking), and use `panic!` only for unrecoverable programming bugs (like indexing out of bounds).
+
+## API Ergonomics
+- Use `impl Into<T>` to accept any convertible type instead of forcing the caller to allocate/convert.
+- Use `impl AsRef<T>` or `&T` to accept any referential type for read-only access.
+- Use `Cow<'a, T>` to avoid allocations on the fast path, cloning only when mutation is necessary.
+- Prefer returning specific, validated types over raw `String` or numeric primitives to avoid "stringly-typed" APIs.
+
 ## Implementation Details
 - Provide concise, actionable suggestions for refactoring.
 - Show code snippets comparing "before" (un-idiomatic) and "after" (idiomatic).

--- a/.agents/plugins/rust-patterns/skills/refactor_idiomatic_rust/SKILL.md
+++ b/.agents/plugins/rust-patterns/skills/refactor_idiomatic_rust/SKILL.md
@@ -1,0 +1,21 @@
+# Refactor Idiomatic Rust
+
+This skill helps you refactor Rust code into idiomatic patterns based on the "Rust Patterns & Engineering How-Tos" guide.
+When asked to refactor or review Rust code for idiomatic usage, apply the principles derived from:
+https://microsoft.github.io/RustTraining/rust-patterns-book/
+
+## Generics and Monomorphization
+- Prefer **Generics (Static Dispatch)** when dealing with a closed set of types or when performance in hot loops is critical (e.g., millions of calls). Generics are zero-cost abstractions as they inline perfectly, but be mindful of code bloat.
+- Prefer **Trait Objects (`dyn Trait` Dynamic Dispatch)** for cold paths, heterogeneous collections, plugin systems, or when the cost of monomorphization code bloat outweighs the minor cost of vtable lookup.
+- Use **`const fn`** where possible for simple constructors or logic that can be evaluated at compile time, reducing runtime overhead.
+
+## Traits and Composition
+- Distinguish between **Associated Types** (when there is *one* output/result per implementing type, e.g., `Iterator::Item`) and **Generic Parameters** (when a type can implement the trait for *many* target types, e.g., `From<T>`).
+- Consider using **Enum Dispatch** as a middle ground between Generics and `dyn Trait`. If the set of types is closed, placing them in an enum and implementing the trait on the enum gives static dispatch performance with dynamic-like flexibility without heap allocation or vtable cost.
+- Apply the **Extension Trait** pattern to safely add methods to foreign types (types you don't own). Define a trait with your method and provide a blanket implementation (`impl<T: SomeBound> MyExtension for T`).
+- Use **Blanket Implementations** carefully but effectively (e.g. `impl<T: Display> ToString for T`) to give trait implementations for free to any type matching the constraints.
+- Maintain **Trait Object Safety Rules**: Traits meant for dynamic dispatch must not have `Self: Sized` bounds on methods meant for the vtable, no generic type parameters on methods, and no `Self` in return position (unless boxed).
+
+## Implementation Details
+- Provide concise, actionable suggestions for refactoring.
+- Show code snippets comparing "before" (un-idiomatic) and "after" (idiomatic).


### PR DESCRIPTION
Adds an Antigravity IDE plugin to equip the agent with specialized Rust skills.
The plugin includes:
- `plugin.json`: Plugin manifest.
- `skills/refactor_idiomatic_rust/SKILL.md`: Instructs the agent on idiomatic Rust refactoring based on the provided Rust Patterns book.
- `skills/architectural_review/SKILL.md`: Equips the agent to review systems architecture using concepts like Capability Mixins and Typed Commands.
- `rules/rust_best_practices.md`: A rule file detailing Rust best practices around monomorphization and static/dynamic dispatch.

---
*PR created automatically by Jules for task [2208463924076138443](https://jules.google.com/task/2208463924076138443) started by @EmilLindfors*