### PR TITLE
feat(antigravity): add hexagonal-architecture guidance to rust-patterns plugin

### DIFF
--- a/.agents/plugins/rust-patterns/commands/rust-review.md
+++ b/.agents/plugins/rust-patterns/commands/rust-review.md
@@ -1,0 +1,55 @@
+---
+description: Review the current Rust diff (or specified files/PR) for idiomatic Rust patterns and hexagonal-architecture compliance, in one pass.
+argument-hint: "[scope] — optional: 'diff' (default), 'branch', a path, or a PR number"
+---
+
+# /rust-review
+
+Run a combined Rust-patterns and hexagonal-architecture review over the scope given in `$ARGUMENTS` (default: the working-tree diff against the merge base of the current branch).
+
+## Procedure
+
+1. **Determine scope.**
+   - If `$ARGUMENTS` is empty or `diff`, review uncommitted changes plus committed changes on the current branch vs. its merge base with `main`/`master`. Use `git diff` and `git log` to enumerate touched files.
+   - If `$ARGUMENTS` is `branch`, review every Rust file changed on the current branch vs. its merge base.
+   - If `$ARGUMENTS` looks like a path or glob, review those files.
+   - If `$ARGUMENTS` is a number (a PR), fetch that PR's diff via the available GitHub tooling and review it.
+
+2. **First pass — idiomatic Rust.** Apply the `refactor_idiomatic_rust` skill. Flag: generics vs. `dyn` misuse, missing `?`/error-propagation cleanups, imperative loops that would read better as combinators, weak closure bounds, stringly-typed APIs, missing `impl Into`/`AsRef`/`Cow` opportunities, panic-prone code in expected-failure paths.
+
+3. **Second pass — advanced architecture.** Apply the `architectural_review` skill. Flag: opportunities for capability mixins, typed commands replacing untyped buffers, mis-chosen concurrency primitives (Mutex where atomic/channel fits), unbounded channels, `lazy_static!` instead of `OnceLock`/`LazyLock`, library code returning `anyhow::Error`.
+
+4. **Third pass — hexagonal compliance.** Apply the `hexagonal_review` skill against the touched files. Flag the smells listed in `rules/hexagonal_architecture.md` §8: domain leaking framework types, ports exposing technology, errors leaking up, services constructing adapters, feature flags on the wrong layer.
+
+5. **Synthesize.** Combine findings into a single review. **Deduplicate** — if one root cause produces findings across multiple passes (e.g. "this port returns `reqwest::Error`" is both an error-architecture issue and a hex-boundary leak), report it once and tag it with both passes it came from.
+
+## Output
+
+```
+## Summary
+<2–4 sentences. Overall verdict. Highest-leverage change.>
+
+## Findings
+
+### 🟥 Blocking — <count>
+- `path/to/file.rs:LL` — <pass tag> — <smell>. Fix: <concrete suggestion>.
+
+### 🟧 Important — <count>
+- `path/to/file.rs:LL` — <pass tag> — <smell>. Fix: <concrete suggestion>.
+
+### 🟨 Suggestions — <count>
+- `path/to/file.rs:LL` — <pass tag> — <smell>. Fix: <concrete suggestion>.
+
+## Next step
+<Optional. If multiple findings share a root cause, name the single change that resolves the most.>
+```
+
+Pass tags: `[idiomatic]`, `[architecture]`, `[hex]`.
+
+## Rules
+
+- Cite file paths and line numbers. Vague advice without locations is not a finding.
+- Do not list cosmetic style preferences (formatting, naming bikesheds) — `rustfmt` and `clippy` own those.
+- Be specific about the *why*. "Use `OnceLock`" is not enough; "Use `OnceLock` instead of `lazy_static!` — std-only, no macro, supports `const` initializers" is.
+- If the diff has no real findings, say so in one sentence. Do not pad with weak suggestions.
+- Never invent code that isn't there. If you suspect a problem in code that wasn't read, read it before flagging it.

--- a/.agents/plugins/rust-patterns/plugin.json
+++ b/.agents/plugins/rust-patterns/plugin.json
@@ -1,3 +1,27 @@
 {
-  "name": "rust-patterns"
+  "name": "rust-patterns",
+  "version": "0.1.0",
+  "description": "Guidance for idiomatic Rust and hexagonal architecture. Combines the Microsoft Rust Patterns Book (https://microsoft.github.io/RustTraining/rust-patterns-book/) with ports-and-adapters discipline for libraries and services.",
+  "keywords": [
+    "rust",
+    "architecture",
+    "hexagonal",
+    "ports-and-adapters",
+    "idiomatic",
+    "code-review",
+    "refactor"
+  ],
+  "commands": [
+    "commands/rust-review.md"
+  ],
+  "skills": [
+    "skills/architectural_review",
+    "skills/refactor_idiomatic_rust",
+    "skills/hexagonal_review",
+    "skills/refactor_to_hexagonal"
+  ],
+  "rules": [
+    "rules/rust_best_practices.md",
+    "rules/hexagonal_architecture.md"
+  ]
 }

--- a/.agents/plugins/rust-patterns/rules/hexagonal_architecture.md
+++ b/.agents/plugins/rust-patterns/rules/hexagonal_architecture.md
@@ -1,0 +1,73 @@
+# Hexagonal Architecture (Ports & Adapters) in Rust
+
+When writing, reviewing, or refactoring Rust code that follows hexagonal architecture, enforce these rules. They complement `rust_best_practices.md` — apply both.
+
+## 1. The Dependency Rule (non-negotiable)
+
+Source code dependencies point **inward only**: `adapter → application → domain`. The domain knows nothing about the application; the application knows nothing about adapters. If a domain file `use`s an HTTP client, a database driver, or a web framework, that is a bug.
+
+- **Domain** (`domain/`): pure types, value objects, domain errors, validation. No I/O, no async runtime, no framework types. `serde` derives are acceptable; `reqwest`/`axum`/`sqlx`/`tokio::net` are not.
+- **Application** (`application/` or `services/`): use-case orchestration. Depends on **port traits**, never on concrete adapters. No `#[cfg(feature = "http-server")]` here — feature gating belongs at the adapter layer.
+- **Ports** (`port/`): trait definitions, owned by the inner layers, expressing what the application needs from the outside world.
+- **Adapters** (`adapter/`): concrete implementations of ports. The only layer allowed to import third-party I/O, framework, or driver crates.
+
+## 2. Ports group by business capability, not by technology
+
+A port is one trait per **capability** (`TaskManager`, `MessageHandler`, `NotificationManager`, `Authenticator`). Do **not** create `HttpPort`, `DatabasePort`, or `SqlitePort` — those are adapter concerns.
+
+- Keep traits narrow. If a trait grows past ~6–8 methods, it is probably two capabilities.
+- Provide sync **and** async variants only when both are genuinely needed by callers (`TaskManager` and `AsyncTaskManager`). Don't duplicate by reflex.
+- Default method implementations on the trait are fine for cross-cutting validation that every adapter would otherwise repeat (e.g. `validate_task_params`).
+
+## 3. Adapters group by technical concern
+
+Within `adapter/`, sub-modules are organized by **what kind of outside world** they touch:
+
+```
+adapter/
+  transport/     // HTTP, WebSocket, gRPC — protocol surfaces
+  storage/       // databases, filesystem — persistence
+  auth/          // JWT, OAuth2, API key — credentials
+  business/      // composite/orchestrating adapters (e.g. a request processor)
+  error/         // adapter-specific error types
+```
+
+One adapter implements one port. If an adapter implements two ports, ask whether it should be split.
+
+## 4. Errors cross the boundary by conversion, never by leak
+
+- Domain defines a domain error enum (`A2AError`, `MyDomainError`) with `thiserror`.
+- Adapters define their own error type (`HttpClientError`, `SqlxStorageError`) with `thiserror`.
+- The adapter's error type implements `From<…>` for the lower-level errors it wraps (reqwest, sqlx, etc.).
+- At the port boundary, the adapter converts its error into the domain error before returning. Use `#[from]` variants on the domain error enum where the conversion is unambiguous.
+- **Libraries** return strongly typed domain errors. **Binaries** may use `anyhow::Result` at the outermost layer (main, CLI handlers) but not inside library crates.
+- Never let `reqwest::Error`, `sqlx::Error`, or `axum::Error` appear in a port trait signature.
+
+## 5. Feature flags gate adapters, not domain or ports
+
+- Domain and port modules must compile with **zero features** enabled.
+- Each optional adapter lives behind its own feature (`http-server`, `sqlite`, `auth`).
+- Re-exports at the crate root that depend on a feature must be `#[cfg(feature = "…")]`-gated.
+- Do not feature-gate trait definitions themselves — gate only their implementations.
+
+## 6. Testability is the point
+
+- Domain logic is tested with plain unit tests. No mocks needed; no test doubles needed.
+- Application services are tested against **in-memory adapter implementations** of their ports (`InMemoryTaskStorage`, `NoopAuthenticator`). Provide these in-memory adapters as first-class types, not just in `#[cfg(test)]`.
+- Adapter tests are integration tests against the real outside system (or a containerised one), not against mocks of the framework.
+
+## 7. Composition happens at the edge
+
+- `main` (or a `bootstrap`/`wire` module) is the only place that picks concrete adapters and assembles them into the application.
+- Application code accepts ports by generic parameter (`<T: TaskManager>`) or `Arc<dyn TaskManager>` — choose static dispatch by default, `dyn` only when you genuinely need heterogeneity or plugin-style extensibility (see `rust_best_practices.md` rules 2 and 3).
+- Do not call `MyConcreteAdapter::new()` from inside a service. That couples the inner layer to the outer layer.
+
+## 8. Smells to flag in review
+
+- A `domain/` file that imports `reqwest`, `axum`, `sqlx`, `tokio::net`, or `tokio::fs`.
+- A port trait whose method signature exposes an HTTP type, a SQL row, or a framework request/response.
+- A `Box<dyn Error>` or `anyhow::Error` in a library-internal port return type.
+- An application service that constructs a concrete adapter directly instead of receiving it.
+- Adapter modules organized by *port name* (`adapter/task_manager/`) instead of by *technology* (`adapter/storage/`, `adapter/transport/`).
+- A feature flag that gates anything in `domain/` or `port/`.
+- A port that exists to model one specific technology (`PostgresPort`, `HttpPort`) — collapse it back into the capability it secretly is.

--- a/.agents/plugins/rust-patterns/skills/architectural_review/SKILL.md
+++ b/.agents/plugins/rust-patterns/skills/architectural_review/SKILL.md
@@ -1,3 +1,8 @@
+---
+name: architectural_review
+description: Review Rust code for advanced architectural patterns — capability mixins, typed commands, concurrency model choice, smart pointer/interior mutability selection, error-handling architecture, and memory layout. Use when the user asks to review system architecture, suggest broad design improvements, or evaluate trait composition and shared-state strategy in a Rust project. For ports-and-adapters layering specifically, prefer `hexagonal_review`.
+---
+
 # Architectural Review (Rust)
 
 This skill helps you perform an architectural review of Rust code based on advanced patterns found in the "Rust Patterns & Engineering How-Tos" guide.

--- a/.agents/plugins/rust-patterns/skills/hexagonal_review/SKILL.md
+++ b/.agents/plugins/rust-patterns/skills/hexagonal_review/SKILL.md
@@ -1,0 +1,70 @@
+---
+name: hexagonal_review
+description: Review a Rust codebase for hexagonal architecture compliance — dependency direction, port shape, adapter grouping, error boundaries, feature-flag placement, and testability. Use when the user asks to review architecture, audit layering, check ports-and-adapters discipline, or evaluate whether a Rust project's structure is sound.
+---
+
+# Hexagonal Review (Rust)
+
+Audit a Rust codebase against the ports-and-adapters discipline defined in `rules/hexagonal_architecture.md`. This skill complements `architectural_review` (which covers Rust patterns generally) by focusing specifically on layering, boundaries, and dependency direction.
+
+## What to inspect
+
+Work through the codebase systematically. For each layer, check:
+
+### Domain layer
+- Are domain types free of I/O, async runtimes, and framework imports?
+- Are domain errors defined with `thiserror` as exhaustive enums?
+- Are invariants enforced at construction (`TryFrom`, newtypes) rather than re-validated everywhere?
+- Does the domain compile with **no feature flags** enabled?
+
+### Port layer
+- Is each port a **narrow capability trait**, not a technology trait?
+- Do port method signatures use **domain types only** — never `reqwest::Response`, `sqlx::Row`, `axum::extract::*`, raw `serde_json::Value` blobs, or generic byte buffers?
+- Do port return types use the **domain error type**, not adapter errors or `Box<dyn Error>` / `anyhow::Error`?
+- Are sync and async variants both warranted? (Don't duplicate by reflex.)
+- Is the port trait object-safe only if you actually use `dyn` dispatch on it? If not, drop the constraint and gain flexibility.
+
+### Application / service layer
+- Do services depend on **port traits only**, never on concrete adapter types?
+- Are concrete adapters constructed elsewhere (in `main`, in a wiring module) and **injected** into the service?
+- Is the service free of `#[cfg(feature = "…")]` gates? Feature gating belongs at the adapter boundary.
+
+### Adapter layer
+- Are adapters grouped by **technical concern** (`transport/`, `storage/`, `auth/`) rather than by port name?
+- Does each adapter convert its lower-level errors (`reqwest::Error`, `sqlx::Error`) into the **domain error** before returning across the port boundary?
+- Are framework-specific re-exports at the crate root properly `#[cfg(feature = "…")]`-gated?
+- Is there an **in-memory adapter** for every port, available outside `#[cfg(test)]` so downstream users can test against it too?
+
+### Composition root
+- Is there exactly one place (typically `main`, a `bootstrap` module, or a builder) where concrete adapters are picked and wired together?
+- Does that place use generics (`<T: TaskManager>`) for static dispatch by default, falling back to `Arc<dyn TaskManager>` only when heterogeneity or plugin extension is genuinely required?
+
+## Smells — flag and explain
+
+When you find any of these, name the file, quote the offending signature, and explain the leak:
+
+1. **Domain dependency leak** — `domain/*.rs` importing an adapter-layer crate.
+2. **Port leaking technology** — a trait method returning `reqwest::Response`, taking `axum::extract::Json<T>`, or exposing a raw SQL row.
+3. **Error leaking up** — `Result<T, sqlx::Error>` or `anyhow::Result<T>` in a library-internal port.
+4. **Service constructing adapters** — `MyService::new()` calling `HttpClient::new(...)` directly.
+5. **Adapter folder shaped by port** — `adapter/task_manager/` instead of `adapter/storage/in_memory_task.rs`.
+6. **Feature-gated port** — `#[cfg(feature = "http")] pub trait MyPort` (gate the impl, not the trait).
+7. **God port** — a single trait with 12+ methods spanning unrelated capabilities. Split it.
+8. **Untyped swamp at the boundary** — ports passing `Vec<u8>`, `serde_json::Value`, or stringly-typed config across the seam instead of validated newtypes.
+
+## Output format
+
+Produce a review with three sections:
+
+1. **Summary** — overall verdict in 2–4 sentences. Where is the architecture strong, where is it leaking.
+2. **Findings** — numbered list. Each finding cites `path/to/file.rs:line`, names the smell from the list above (or describes a new one), and proposes a concrete fix.
+3. **Optional next steps** — if multiple findings share a root cause (e.g. "the domain error type doesn't have a variant for storage failures, so adapters are leaking `sqlx::Error` upward"), call that out as the single highest-leverage change.
+
+Keep findings actionable. Do not list cosmetic style nits — those belong to `refactor_idiomatic_rust`.
+
+## When this skill is NOT the right tool
+
+- If the user is asking about generic Rust idioms (generics vs. dyn, error handling style, iterator chains), invoke `refactor_idiomatic_rust` or `architectural_review` instead.
+- If the user wants a step-by-step migration of a non-hexagonal codebase **toward** ports and adapters, use `refactor_to_hexagonal`.
+
+Source for the underlying patterns: https://microsoft.github.io/RustTraining/rust-patterns-book/

--- a/.agents/plugins/rust-patterns/skills/refactor_idiomatic_rust/SKILL.md
+++ b/.agents/plugins/rust-patterns/skills/refactor_idiomatic_rust/SKILL.md
@@ -1,3 +1,8 @@
+---
+name: refactor_idiomatic_rust
+description: Refactor Rust code toward idiomatic patterns — generics vs dyn, associated vs generic trait parameters, enum dispatch, extension traits, closure bounds, iterator combinators, API ergonomics (Into/AsRef/Cow), and clean error propagation. Use when the user asks to make code more idiomatic, clean up a function, choose between dispatch strategies, or tighten an API surface.
+---
+
 # Refactor Idiomatic Rust
 
 This skill helps you refactor Rust code into idiomatic patterns based on the "Rust Patterns & Engineering How-Tos" guide.

--- a/.agents/plugins/rust-patterns/skills/refactor_to_hexagonal/SKILL.md
+++ b/.agents/plugins/rust-patterns/skills/refactor_to_hexagonal/SKILL.md
@@ -1,0 +1,101 @@
+---
+name: refactor_to_hexagonal
+description: Guide an incremental migration of an existing Rust codebase toward ports-and-adapters / hexagonal architecture. Use when the user wants to refactor a tangled service, extract a domain core, introduce port traits, or split a monolithic module into domain/port/adapter layers without a big-bang rewrite.
+---
+
+# Refactor to Hexagonal (Rust)
+
+Drive an **incremental** migration from a flat or layered-by-framework Rust codebase to one organized by ports and adapters. The goal is small, reviewable PRs — never a big-bang rewrite.
+
+Read `rules/hexagonal_architecture.md` first; this skill operationalizes those rules into a migration sequence.
+
+## When to recommend this refactor
+
+Recommend hex when you see at least two of:
+- Business logic interleaved with HTTP handlers or DB queries.
+- A test suite that needs a running database or HTTP mock to exercise core logic.
+- Difficulty swapping infrastructure (e.g. "we want to try Postgres alongside SQLite" or "we want a CLI version of this service").
+- Errors from `sqlx`, `reqwest`, `axum`, etc. propagating up through what should be business code.
+
+Do **not** recommend it for:
+- Small CLIs or scripts where there is no real "domain."
+- Pure libraries that already have no I/O.
+- Codebases where the dominant problem is something else (perf, concurrency, type safety) — fix that first.
+
+## Migration sequence
+
+Drive the refactor in this order. Each step should be a separate, mergeable change.
+
+### Step 1 — Carve out a `domain/` module
+
+- Find the data types the business cares about (entities, value objects, status enums) and move them into `domain/`.
+- Strip framework attributes from these types (`#[derive(sqlx::FromRow)]`, `#[serde(rename_all)]` for HTTP, `axum` extractors). If serialization is needed in *every* adapter, keep `serde` derives; if it's only the HTTP adapter, define a DTO there and map.
+- Introduce newtypes for primitive-typed identifiers and bounded values (`struct TaskId(String)`, `struct Port(u16)`). Parse at construction.
+- Define a single `DomainError` enum with `thiserror`. Initially it can have a catch-all variant; tighten over time.
+
+**Done when**: `cargo check -p <crate> --no-default-features` compiles the domain module in isolation, with no third-party I/O crates pulled in.
+
+### Step 2 — Extract one port
+
+Pick the **smallest, highest-pain** capability first. Storage is usually a good first target.
+
+- Define a `trait` in `port/<capability>.rs` whose methods take and return **domain types only**.
+- Methods return `Result<T, DomainError>`, not the adapter's error type.
+- Keep the trait small. If it has more than ~6 methods, you probably picked too coarse a slice — split it.
+
+**Done when**: the trait compiles with only domain types in scope, and no infrastructure crates are imported in the port module.
+
+### Step 3 — Wrap the existing implementation as the first adapter
+
+- Move the existing concrete code (the SQL queries, the HTTP handlers) into `adapter/<concern>/`. Don't rewrite it — move and rename only.
+- Make the existing concrete type `impl` the new port trait. Convert its internal errors to `DomainError` at the trait boundary using `#[from]` variants.
+- Keep the concrete `pub` type available behind a feature flag (`sqlite`, `http-client`).
+
+**Done when**: the rest of the application still calls the same concrete type by name, but now you *could* substitute another impl.
+
+### Step 4 — Add the in-memory adapter
+
+- Implement the port trait with a `HashMap`/`Vec`-backed type in `adapter/<concern>/in_memory.rs`. Expose it from the crate root, **not** behind `#[cfg(test)]`.
+- This is the lever that makes the whole refactor worth doing: now domain and application tests run without infrastructure.
+
+**Done when**: at least one previously-integration test can be rewritten as a fast unit test using the in-memory adapter.
+
+### Step 5 — Invert dependencies at call sites
+
+Now go to each consumer of the concrete adapter and replace it with the port trait.
+
+- For each function that previously took `&SqliteTaskStore`, change it to `<S: TaskStore>` or `&dyn TaskStore`. Prefer the generic by default; reach for `dyn` only on cold paths or heterogeneous collections (see `rust_best_practices.md` rule 2).
+- The call site (typically `main` or a builder) is the one place that still names the concrete adapter.
+
+**Done when**: a `grep` for the concrete adapter type returns only its definition, its `impl` blocks, and the composition root.
+
+### Step 6 — Add the application/service layer
+
+Only after at least one port is fully inverted:
+
+- Move use-case orchestration into `application/` or `services/`. These functions take ports as generic parameters.
+- Remove `#[cfg(feature = "…")]` from this layer. If you can't, a leak from step 5 wasn't actually fixed — go back.
+
+### Step 7 — Repeat
+
+Pick the next port (auth, notifications, transport) and run steps 2–5 again. Each capability is its own small PR.
+
+## Anti-patterns during migration
+
+Flag and refuse to do these when the user asks:
+
+- **Boil-the-ocean refactor.** "Let's redesign the whole crate at once." No. One port at a time.
+- **Port-per-technology.** Don't introduce `trait HttpStore` and `trait SqliteStore` — that's the *adapter* layer leaking up. There is one `TaskStore` port; there are many adapters.
+- **Generic-everywhere over-engineering.** Don't add a port trait for capabilities that have exactly one implementation and no test seam to gain. Hex is justified by *substitutability* (real impl, fake impl, alternative impl). If none of those exist, the trait is overhead.
+- **Anaemic domain.** Don't extract domain types into `domain/` and leave all the logic in adapters. Pull the rules that operate on those types in with them.
+- **Hex for a CLI tool.** A 200-line CLI that reads a file, transforms it, and writes a file does not need ports.
+
+## Output format
+
+When asked to plan or perform a migration, produce:
+
+1. **Assessment** — 2–4 sentences on whether hex is justified here and which capability is the right first target.
+2. **Migration plan** — numbered steps mapped onto the sequence above, with file paths and approximate diff sizes.
+3. **First-PR diff or patch** — if asked to actually do the work, perform **only Step 1 (or Step 2 if Step 1 is already done)** and stop there. Do not chain steps in one change.
+
+Source for the underlying Rust patterns: https://microsoft.github.io/RustTraining/rust-patterns-book/


### PR DESCRIPTION
Adds a hexagonal-architecture rule, a hex review skill, and a refactor-to-hex skill so the plugin nudges toward ports-and-adapters discipline alongside the existing Rust idiom guidance. Ships a /rust-review command that runs idiomatic, architectural, and hex passes in one go. Fleshes out plugin.json and adds the YAML frontmatter the existing skills were missing so they're discoverable.