### PR TITLE
ci: fix release-plz.toml so the release PR can open

### DIFF
--- a/release-plz.toml
+++ b/release-plz.toml
@@ -60,6 +60,4 @@ commit_parsers = [
   { message = "^chore", skip = true },
   { message = ".*", group = "Other" },
 ]
-# Drop merge commits.
-filter_commits = false
 protect_breaking_commits = true


### PR DESCRIPTION
`release-plz.toml` carried an invalid `filter_commits` field under `[changelog]`, which is not in release-plz's allowed schema. Every release-plz run since the file was added (incl. the 0.4 merge) failed with `invalid config file` and **no release PR was ever opened**.

This removes the offending line (also self-contradictory: comment said "drop merge commits" but `= false` keeps them).

Once merged, release-plz will open the standard "chore: release" PR. Verified locally with `release-plz update` (0.3.132) — proposes:

- a2a-rs / a2a-agents / a2a-web-client / a2a-mcp → 0.4.0
- a2a-ap2 / a2a-agents-common → 0.3.1 (will be bumped to 0.4.0 in the release PR for lockstep)

🤖 Generated with [Claude Code](https://claude.com/claude-code)