### PR TITLE
chore(a2a-ap2): repair changelog corrupted by 0.3.1 release

### DIFF
--- a/a2a-ap2/CHANGELOG.md
+++ b/a2a-ap2/CHANGELOG.md
@@ -6,9 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-# Changelog
 
-All notable changes to this project will be documented in this file.
+## [0.3.1](https://github.com/EmilLindfors/a2a-rs/compare/a2a-ap2-v0.3.0...a2a-ap2-v0.3.1) - 2026-06-05
+
+### Other
+
+- Updated the following local packages: a2a-rs (0.3 -> 0.4)
 
 ## [0.3.0](https://github.com/EmilLindfors/a2a-rs/compare/a2a-ap2-v0.2.0...a2a-ap2-v0.3.0) - 2026-05-27
 


### PR DESCRIPTION
The 0.4.0 release surfaced a release-plz changelog glitch isolated to **a2a-ap2**: when it published 0.3.1, release-plz inserted a duplicate `# Changelog` header block under `## [Unreleased]` instead of a `## [0.3.1]` section. The malformed file then caused a follow-up empty release PR (#26, now closed) that would have re-corrupted it on merge.

This removes the stray header block and adds the correct 0.3.1 entry (dependency-only bump, a2a-rs 0.3 → 0.4). The other five crates' changelogs were unaffected.

`chore:` prefix → skipped by the changelog commit parser, so this does not trigger a new release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)