### PR TITLE
feat(a2acli): A2A command-line client + promote auto_connect into a2a-rs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -154,7 +154,6 @@ dependencies = [
  "buffa",
  "futures",
  "futures-util",
- "reqwest",
  "serde",
  "serde_json",
  "thiserror 2.0.18",
@@ -162,6 +161,21 @@ dependencies = [
  "tracing",
  "uuid",
  "wiremock",
+]
+
+[[package]]
+name = "a2acli"
+version = "0.4.0"
+dependencies = [
+ "a2a-rs",
+ "anyhow",
+ "clap",
+ "futures",
+ "serde_json",
+ "tokio",
+ "tracing",
+ "tracing-subscriber",
+ "uuid",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [workspace]
 resolver = "2"
-members = ["a2a-rs", "a2a-agents", "a2a-client", "a2a-ap2", "a2a-agents-common", "a2a-mcp"]
+members = ["a2a-rs", "a2a-agents", "a2a-client", "a2a-ap2", "a2a-agents-common", "a2a-mcp", "a2acli"]
 exclude = ["a2a-mcp/rust-sdk"]
 
 # Common dependencies shared across workspace members. Members reference these

--- a/TODO.md
+++ b/TODO.md
@@ -1,0 +1,63 @@
+# TODO — `a2acli` follow-ups
+
+Working branch: `feat/a2acli`. Tracks the next steps after landing the `a2acli`
+crate + the `auto_connect` promotion. Companion to `ROADMAP.md` (this is the
+near-term, actionable slice).
+
+## 1. Ship the current branch
+
+- [ ] Commit the staged work on `feat/a2acli` (new `a2acli` crate, `a2a_rs::auto_connect`,
+      `WebA2AClient` delegation, unused-`reqwest` drop from `a2a-client`).
+- [ ] Open the PR. In the description, call out:
+  - the `--auth`/`--timeout` caveat in `auto` mode (item 3 below), and
+  - the agent-card transport-mislabel finding (item 4 below).
+- [ ] Add `a2acli` to the workspace table in `CLAUDE.md` (currently lists the six
+      library crates but not the new bin crate).
+
+## 2. Bugs found while testing the CLI (not CLI bugs)
+
+- [ ] **Agent card mislabels its transport.** `a2a-agents` `AgentBuilder`/runtime
+      (`a2a-agents/src/core/runtime.rs`) mounts a **ConnectRPC** server
+      (`ConnectRpcAdapter` + `HttpServer`) but the published card advertises the
+      interface as **`JSONRPC`** (the `SimpleAgentInfo` default `protocol_binding`).
+      Client auto-negotiation then picks the JSON-RPC client and fails
+      (`invalid JSON-RPC response: error decoding response body`); `--transport
+      connectrpc` works. Fix card generation so `protocol_binding` matches the
+      mounted adapter. *Observed against `complex_agent` on :8080.*
+- [ ] **ConnectRPC SSE subscription never closes on terminal state.** `a2acli stream`
+      (and any subscriber) stays open after the task reaches `FAILED`/`COMPLETED`;
+      had to cap each run with `timeout`. The stream should end when the task hits a
+      terminal state. (Distinct from the `Last-Event-ID` gap in `ROADMAP.md`.)
+
+## 3. CLI follow-ups
+
+- [ ] **Thread `--auth`/`--timeout` through `auto` mode.** Today the negotiation
+      factories (`TransportFactory` in `a2a-rs/src/adapter/transport/negotiation.rs`)
+      build unauthenticated, default-timeout clients, so credentials only apply with
+      an explicit `--transport`. Options: add a `ClientConfig` (token + timeout) to
+      `TransportFactory::create`, or a `connect_with`/`auto_connect_with` variant.
+- [ ] **Add an `a2acli` integration test.** Spin up `examples/jsonrpc_server` and
+      drive the built binary through `card`/`send`/`get`/`cancel` (mirrors the manual
+      e2e). Complements `a2a-rs/tests/jsonrpc_client_interop_test.rs`.
+- [ ] **(Optional) `list` command** — the `Transport` port already has `list_tasks`;
+      expose it (`a2acli list [--state …] [--limit …]`). Push-notification-config
+      commands (`set`/`get`/`list`/`delete`) are also available on the port but are
+      out of the roadmap's `card/send/stream/get/cancel` scope.
+
+## 4. Cross-SDK interop validation (ROADMAP §0.5)
+
+- [ ] Point the **official** `a2aproject/a2acli` at our
+      `examples/jsonrpc_server` (`:8137`) — validates our *server* against the
+      canonical client.
+- [ ] Point **our** `JsonRpcClient`/`a2acli` at a stock upstream A2A agent —
+      validates our *client* against other SDKs.
+- [ ] Once both pass, capture the matrix (which transports/SDKs interoperate) in the
+      `a2acli` README or `ROADMAP.md`.
+
+## 5. Example/test ergonomics (minor)
+
+- [ ] `complex_agent`'s rule-based path is unreachable env-only:
+      `OpenAiProvider::from_env()` always returns `Ok` (it defaults base-url/model),
+      so `load_llm()` never returns `None`. Add an opt-out (e.g. `A2A_NO_LLM=1` or a
+      `--no-llm` flag) so the deterministic, no-network streaming path can be
+      exercised in demos/tests without standing up an LLM endpoint.

--- a/a2a-client/CHANGELOG.md
+++ b/a2a-client/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- *(a2a-web-client)* `WebA2AClient::auto_connect` now delegates to `a2a_rs::auto_connect` (shared entry point); a malformed URL surfaces as `A2AError::InvalidParams`. Dropped the now-unused `reqwest` dependency.
+
 ## [0.4.0](https://github.com/EmilLindfors/a2a-rs/compare/a2a-web-client-v0.3.0...a2a-web-client-v0.4.0) - 2026-06-05
 
 ### Added

--- a/a2a-client/Cargo.toml
+++ b/a2a-client/Cargo.toml
@@ -33,9 +33,6 @@ serde_json = { workspace = true }
 anyhow = { workspace = true }
 thiserror = { workspace = true }
 
-# Reqwest for URL parsing and handling
-reqwest = { workspace = true }
-
 # Logging
 tracing = { workspace = true }
 

--- a/a2a-client/src/lib.rs
+++ b/a2a-client/src/lib.rs
@@ -220,19 +220,13 @@ impl WebA2AClient {
     /// # }
     /// ```
     pub async fn auto_connect(base_url: &str) -> Result<Self> {
-        // Validate URL format up front so a malformed URL is a hard error.
-        let _ = reqwest::Url::parse(base_url).map_err(|e| ClientError::InvalidUrl {
-            url: base_url.to_string(),
-            reason: e.to_string(),
-        })?;
-
-        match a2a_rs::connect(base_url, &a2a_rs::default_registry()).await {
-            Ok(transport) => Ok(Self {
-                transport: Arc::from(transport),
-            }),
-            // Card fetch / negotiation failed — fall back to a direct ConnectRPC client.
-            Err(_) => Ok(Self::new_http(base_url.to_string())),
-        }
+        // Delegates to the shared `a2a_rs::auto_connect` (URL-validate → negotiate
+        // → direct-client fallback); the CLI and this web client are siblings on
+        // that one entry point.
+        let transport = a2a_rs::auto_connect(base_url).await?;
+        Ok(Self {
+            transport: Arc::from(transport),
+        })
     }
 
     /// Subscribe to a task's updates as a protocol-neutral stream of
@@ -432,14 +426,18 @@ mod tests {
 
     #[tokio::test]
     async fn test_auto_connect_invalid_url() {
-        let result = WebA2AClient::auto_connect("invalid-url-no-scheme").await;
-        assert!(result.is_err());
-        match result {
-            Err(ClientError::InvalidUrl { url, reason }) => {
-                assert_eq!(url, "invalid-url-no-scheme");
-                assert!(!reason.is_empty());
+        // URL validation now lives in `a2a_rs::auto_connect`, so a malformed URL
+        // surfaces as an `A2AError::InvalidParams` wrapped in `ClientError::A2AError`.
+        // `WebA2AClient` isn't `Debug`, so discard the Ok value before matching.
+        let err = WebA2AClient::auto_connect("invalid-url-no-scheme")
+            .await
+            .err()
+            .expect("malformed url should error");
+        match err {
+            ClientError::A2AError(A2AError::InvalidParams(msg)) => {
+                assert!(msg.contains("invalid-url-no-scheme"), "got {msg}");
             }
-            _ => panic!("Expected ClientError::InvalidUrl"),
+            other => panic!("Expected ClientError::A2AError(InvalidParams), got {other:?}"),
         }
     }
 }

--- a/a2a-rs/CHANGELOG.md
+++ b/a2a-rs/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- *(a2a-rs)* `auto_connect` — URL-validate → card-driven negotiation → direct-client fallback, shared by the CLI and web client (behind the client features)
+
 ## [0.4.0](https://github.com/EmilLindfors/a2a-rs/compare/a2a-rs-v0.3.0...a2a-rs-v0.4.0) - 2026-06-05
 
 ### Added

--- a/a2a-rs/src/adapter/mod.rs
+++ b/a2a-rs/src/adapter/mod.rs
@@ -29,7 +29,7 @@ pub use transport::jsonrpc_client::JsonRpcClient;
 #[cfg(feature = "client")]
 pub use transport::negotiation::{TransportFactory, TransportNegotiator, default_registry};
 #[cfg(any(feature = "http-client", feature = "jsonrpc-client"))]
-pub use transport::negotiation::{connect, fetch_agent_card};
+pub use transport::negotiation::{auto_connect, connect, fetch_agent_card};
 #[cfg(feature = "client")]
 pub use transport::retry::{RetryingTransport, subscribe_resilient};
 

--- a/a2a-rs/src/adapter/transport/negotiation.rs
+++ b/a2a-rs/src/adapter/transport/negotiation.rs
@@ -167,6 +167,43 @@ pub async fn connect(
     negotiator.negotiate(&card).await
 }
 
+/// Validate `base_url`, negotiate a transport from the agent card, and fall back
+/// to a direct client when the card can't be fetched or none of its interfaces
+/// match a compiled-in transport.
+///
+/// This is the one-call ergonomic entry point shared by the CLI and the web
+/// client: it validates the URL up front (so a malformed URL is a hard error),
+/// tries [`connect`] with the [`default_registry`], and on any negotiation miss
+/// falls back to a direct client on `base_url` so the call still works against a
+/// bare agent URL with no published card. The fallback prefers the in-tree
+/// ConnectRPC transport, using JSON-RPC 2.0 when ConnectRPC isn't compiled in.
+#[cfg(any(feature = "http-client", feature = "jsonrpc-client"))]
+pub async fn auto_connect(base_url: &str) -> Result<Box<dyn Transport>, A2AError> {
+    // Validate URL format up front so a malformed URL is a hard error rather
+    // than a silent fallback to a client that will fail on first request.
+    reqwest::Url::parse(base_url)
+        .map_err(|e| A2AError::InvalidParams(format!("invalid url {base_url}: {e}")))?;
+
+    match connect(base_url, &default_registry()).await {
+        Ok(transport) => Ok(transport),
+        // Card fetch / negotiation failed — fall back to a direct client.
+        Err(_) => Ok(direct_transport(base_url)),
+    }
+}
+
+/// Build a direct client on `base_url`, preferring ConnectRPC when compiled in.
+#[cfg(any(feature = "http-client", feature = "jsonrpc-client"))]
+fn direct_transport(base_url: &str) -> Box<dyn Transport> {
+    #[cfg(feature = "http-client")]
+    {
+        Box::new(super::http::HttpClient::new(base_url.to_string()))
+    }
+    #[cfg(all(not(feature = "http-client"), feature = "jsonrpc-client"))]
+    {
+        Box::new(super::jsonrpc_client::JsonRpcClient::new(base_url.to_string()))
+    }
+}
+
 /// Fetch an [`AgentCard`] from the agent's well-known endpoint (plain HTTP GET).
 #[cfg(any(feature = "http-client", feature = "jsonrpc-client"))]
 pub async fn fetch_agent_card(base_url: &str) -> Result<AgentCard, A2AError> {
@@ -191,4 +228,48 @@ pub async fn fetch_agent_card(base_url: &str) -> Result<AgentCard, A2AError> {
     Err(A2AError::Internal(format!(
         "Agent card not found at {base_url}"
     )))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn rejects_v2_interface() {
+        assert!(version_compatible("1.0"));
+        assert!(version_compatible("")); // unspecified accepted
+        assert!(!version_compatible("2.0"));
+    }
+
+    #[cfg(any(feature = "http-client", feature = "jsonrpc-client"))]
+    #[tokio::test]
+    async fn auto_connect_rejects_malformed_url() {
+        // `Box<dyn Transport>` isn't `Debug`, so match rather than `unwrap_err`.
+        match auto_connect("not-a-url").await {
+            Err(A2AError::InvalidParams(_)) => {}
+            Err(other) => panic!("wrong error: {other:?}"),
+            Ok(_) => panic!("expected an error for a malformed url"),
+        }
+    }
+
+    // A well-formed URL with no agent published there: card fetch fails, so
+    // `auto_connect` must fall back to a direct client rather than erroring.
+    // Port 1 is reserved/unroutable, so the GET fails fast.
+    #[cfg(feature = "http-client")]
+    #[tokio::test]
+    async fn auto_connect_falls_back_to_direct_connectrpc() {
+        let transport = auto_connect("http://127.0.0.1:1")
+            .await
+            .expect("fallback yields a direct transport");
+        assert_eq!(transport.protocol(), "CONNECTRPC");
+    }
+
+    #[cfg(all(not(feature = "http-client"), feature = "jsonrpc-client"))]
+    #[tokio::test]
+    async fn auto_connect_falls_back_to_direct_jsonrpc() {
+        let transport = auto_connect("http://127.0.0.1:1")
+            .await
+            .expect("fallback yields a direct transport");
+        assert_eq!(transport.protocol(), "JSONRPC");
+    }
 }

--- a/a2a-rs/src/adapter/transport/negotiation.rs
+++ b/a2a-rs/src/adapter/transport/negotiation.rs
@@ -200,7 +200,9 @@ fn direct_transport(base_url: &str) -> Box<dyn Transport> {
     }
     #[cfg(all(not(feature = "http-client"), feature = "jsonrpc-client"))]
     {
-        Box::new(super::jsonrpc_client::JsonRpcClient::new(base_url.to_string()))
+        Box::new(super::jsonrpc_client::JsonRpcClient::new(
+            base_url.to_string(),
+        ))
     }
 }
 

--- a/a2a-rs/src/lib.rs
+++ b/a2a-rs/src/lib.rs
@@ -114,7 +114,7 @@ pub use adapter::{TransportFactory, TransportNegotiator, default_registry};
 pub use adapter::{RetryingTransport, subscribe_resilient};
 
 #[cfg(any(feature = "http-client", feature = "jsonrpc-client"))]
-pub use adapter::{connect, fetch_agent_card};
+pub use adapter::{auto_connect, connect, fetch_agent_card};
 
 #[cfg(feature = "http-server")]
 pub use adapter::HttpServer;

--- a/a2acli/CHANGELOG.md
+++ b/a2acli/CHANGELOG.md
@@ -1,0 +1,12 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Added
+
+- *(a2acli)* New command-line client driving the `a2a-rs` `Transport` port: `card`, `send`, `get`, `cancel`, `stream`. Endpoint from `A2A_URL` (`--url`/`-u` override); `--transport auto|connectrpc|jsonrpc`; `--json` for machine-readable output. Auto mode negotiates the transport from the agent card with a direct-client fallback. Doubles as a manual cross-SDK interop harness.

--- a/a2acli/Cargo.toml
+++ b/a2acli/Cargo.toml
@@ -1,0 +1,32 @@
+[package]
+name = "a2acli"
+version = "0.4.0"
+edition = "2024"
+rust-version = "1.85"
+authors = ["Emil Lindfors <emil@lindfors.no>"]
+description = "Command-line client for the Agent-to-Agent (A2A) protocol"
+license = "MIT"
+repository = "https://github.com/emillindfors/a2a-rs"
+keywords = ["a2a", "agent", "cli", "client"]
+categories = ["command-line-utilities", "api-bindings"]
+
+[[bin]]
+name = "a2acli"
+path = "src/main.rs"
+
+[dependencies]
+# Drive the client `Transport` port from a2a-rs directly (not a2a-client, which
+# drags in axum/askama for zero CLI benefit). Both wire transports compiled in.
+a2a-rs = { path = "../a2a-rs", version = "0.4", default-features = false, features = [
+    "http-client",
+    "jsonrpc-client",
+    "tracing",
+] }
+clap = { version = "4.4", features = ["derive", "env"] }
+tokio = { workspace = true, features = ["rt-multi-thread", "macros"] }
+anyhow = { workspace = true }
+futures = { workspace = true }
+uuid = { workspace = true }
+serde_json = { workspace = true }
+tracing = { workspace = true }
+tracing-subscriber = { workspace = true }

--- a/a2acli/README.md
+++ b/a2acli/README.md
@@ -1,0 +1,77 @@
+# a2acli
+
+A small command-line client for the **Agent-to-Agent (A2A) protocol**. It drives
+the client `Transport` port from [`a2a-rs`](../a2a-rs) directly — `card`, `send`,
+`get`, `cancel`, `stream` — and doubles as a manual cross-SDK interop harness.
+
+## Install / run
+
+```sh
+cargo run -p a2acli -- <global options> <command>
+# or build the binary:
+cargo build -p a2acli   # target/debug/a2acli
+```
+
+## Endpoint
+
+The agent base URL comes from `--url`/`-u` (alias `--base-url`), falling back to
+the `A2A_URL` environment variable:
+
+```sh
+export A2A_URL=http://localhost:8137
+a2acli card
+# or per-invocation:
+a2acli --url http://localhost:8137 card
+```
+
+## Global options
+
+| Flag | Description |
+|---|---|
+| `-u, --url <URL>` (`--base-url`) | Agent base URL. Env: `A2A_URL`. |
+| `--transport <auto\|connectrpc\|jsonrpc>` | Wire transport. Default `auto` (negotiate from the agent card, ConnectRPC preferred, JSON-RPC 2.0 as interop fallback). |
+| `--auth <TOKEN>` | Bearer token. Env: `A2A_AUTH_TOKEN`. **See caveat below.** |
+| `--timeout <SECS>` | Request timeout. **See caveat below.** |
+| `--json` | Emit raw JSON instead of human-readable output. |
+
+### `--auth` / `--timeout` caveat
+
+The card-driven negotiation factories build *unauthenticated* clients, so
+`--auth` and `--timeout` apply only when you pin a transport with
+`--transport connectrpc` or `--transport jsonrpc`. In the default `auto` mode they
+are ignored (a warning is logged to stderr). Threading credentials through
+transport negotiation is out of scope for the CLI.
+
+## Commands
+
+```sh
+a2acli card                                   # fetch & print the agent card
+a2acli send "hello"                           # send to a fresh (uuid) task id
+a2acli send "hello" --task-id t1              # send to a specific task
+a2acli get t1                                 # fetch a task by id
+a2acli cancel t1                              # cancel a task
+a2acli stream t1                              # subscribe to task updates
+a2acli stream t1 --resilient                  # reconnect with backoff on disconnect
+a2acli stream t1 --resilient --last-event-id 42   # resume from an event id
+```
+
+Add `--json` to any command for machine-readable output (JSON object for
+`card`/`get`/`send`/`cancel`; one JSON envelope per line for `stream`).
+
+## Interop harness
+
+Validate wire-compat against the canonical SDKs by crossing clients and servers:
+
+```sh
+# Terminal 1: our JSON-RPC server
+cargo run -p a2a-rs --example jsonrpc_server --features jsonrpc-server   # binds :8137
+
+# Terminal 2: our CLI against our server
+A2A_URL=http://localhost:8137 cargo run -p a2acli -- card
+A2A_URL=http://localhost:8137 cargo run -p a2acli -- --transport jsonrpc send "hello"
+```
+
+Then point the **official** `a2aproject/a2acli` at the same server, and/or point
+this CLI at a stock A2A agent, to validate against other implementations.
+(`a2a-rs/tests/jsonrpc_client_interop_test.rs` already proves our-client ↔
+our-server byte-compat; this validates against *other* SDKs.)

--- a/a2acli/src/main.rs
+++ b/a2acli/src/main.rs
@@ -30,7 +30,13 @@ struct Cli {
     /// Base URL of the A2A agent (e.g. http://localhost:8137).
     ///
     /// Falls back to the `A2A_URL` environment variable when omitted.
-    #[arg(short, long, env = "A2A_URL", visible_alias = "base-url", global = true)]
+    #[arg(
+        short,
+        long,
+        env = "A2A_URL",
+        visible_alias = "base-url",
+        global = true
+    )]
     url: Option<String>,
 
     /// Bearer token for authenticated agents.
@@ -319,10 +325,7 @@ fn emit_event(json: bool, event: &StreamEvent) -> anyhow::Result<()> {
         return Ok(());
     }
 
-    let id = event
-        .event_id
-        .map(|n| format!("#{n} "))
-        .unwrap_or_default();
+    let id = event.event_id.map(|n| format!("#{n} ")).unwrap_or_default();
     match kind {
         "task" => println!(
             "{id}● task {} [{}]",
@@ -344,11 +347,17 @@ fn emit_event(json: bool, event: &StreamEvent) -> anyhow::Result<()> {
 // --- small JSON helpers ------------------------------------------------------
 
 fn str_field<'a>(value: &'a Value, key: &str) -> Option<&'a str> {
-    value.get(key).and_then(Value::as_str).filter(|s| !s.is_empty())
+    value
+        .get(key)
+        .and_then(Value::as_str)
+        .filter(|s| !s.is_empty())
 }
 
 fn array_field<'a>(value: &'a Value, key: &str) -> Option<&'a Vec<Value>> {
-    value.get(key).and_then(Value::as_array).filter(|a| !a.is_empty())
+    value
+        .get(key)
+        .and_then(Value::as_array)
+        .filter(|a| !a.is_empty())
 }
 
 /// A task's `status.state`, e.g. `"TASK_STATE_SUBMITTED"`.

--- a/a2acli/src/main.rs
+++ b/a2acli/src/main.rs
@@ -1,0 +1,361 @@
+//! `a2acli` — a small command-line client for the Agent-to-Agent (A2A) protocol.
+//!
+//! It drives the client [`Transport`] port from `a2a-rs` directly: `card`,
+//! `send`, `get`, `cancel`, and `stream`. By default it auto-negotiates a
+//! transport from the agent card (ConnectRPC preferred, JSON-RPC 2.0 as interop
+//! fallback); `--transport` forces a specific wire protocol.
+//!
+//! It doubles as a manual cross-SDK interop harness: point it at
+//! `a2a-rs/examples/jsonrpc_server.rs`, or point the official `a2aproject/a2acli`
+//! at the same server, to validate wire-compat against the canonical SDKs.
+
+use std::pin::Pin;
+use std::sync::Arc;
+
+use a2a_rs::domain::{A2AError, AgentCard, Message, Task};
+use a2a_rs::{
+    HttpClient, JsonRpcClient, RetryPolicy, StreamEvent, StreamItem, Transport, subscribe_resilient,
+};
+use anyhow::Context;
+use clap::{Parser, Subcommand, ValueEnum};
+use futures::StreamExt;
+use serde_json::Value;
+
+/// A protocol-neutral stream of task update events.
+type EventStream = Pin<Box<dyn futures::Stream<Item = Result<StreamEvent, A2AError>> + Send>>;
+
+#[derive(Parser)]
+#[command(name = "a2acli", version, about, long_about = None)]
+struct Cli {
+    /// Base URL of the A2A agent (e.g. http://localhost:8137).
+    ///
+    /// Falls back to the `A2A_URL` environment variable when omitted.
+    #[arg(short, long, env = "A2A_URL", visible_alias = "base-url", global = true)]
+    url: Option<String>,
+
+    /// Bearer token for authenticated agents.
+    ///
+    /// Only applied with `--transport connectrpc|jsonrpc`; ignored in the default
+    /// `auto` mode (the negotiation factories build unauthenticated clients).
+    #[arg(long, env = "A2A_AUTH_TOKEN", global = true)]
+    auth: Option<String>,
+
+    /// Request timeout in seconds. Applies to explicit transports only (see `--auth`).
+    #[arg(long, global = true)]
+    timeout: Option<u64>,
+
+    /// Wire transport to use.
+    #[arg(long, value_enum, default_value_t = TransportChoice::Auto, global = true)]
+    transport: TransportChoice,
+
+    /// Emit raw JSON instead of human-readable output.
+    #[arg(long, global = true)]
+    json: bool,
+
+    #[command(subcommand)]
+    command: Command,
+}
+
+#[derive(Copy, Clone, PartialEq, Eq, ValueEnum)]
+enum TransportChoice {
+    /// Negotiate from the agent card, falling back to a direct client.
+    Auto,
+    /// Force the ConnectRPC transport.
+    Connectrpc,
+    /// Force the wire-compatible JSON-RPC 2.0 transport.
+    Jsonrpc,
+}
+
+#[derive(Subcommand)]
+enum Command {
+    /// Fetch and print the agent card.
+    Card,
+
+    /// Send a text message to a task (a task id is generated when omitted).
+    Send {
+        /// The message text.
+        text: String,
+        /// Target task id. Generated (uuid) if not provided.
+        #[arg(long)]
+        task_id: Option<String>,
+        /// Session id to associate the message with.
+        #[arg(long)]
+        session_id: Option<String>,
+        /// Number of history messages to return on the resulting task.
+        #[arg(long)]
+        history_length: Option<u32>,
+    },
+
+    /// Get a task by id.
+    Get {
+        /// The task id.
+        task_id: String,
+        /// Number of history messages to return.
+        #[arg(long)]
+        history_length: Option<u32>,
+    },
+
+    /// Cancel a task by id.
+    Cancel {
+        /// The task id.
+        task_id: String,
+    },
+
+    /// Subscribe to a task's update stream and print events as they arrive.
+    Stream {
+        /// The task id.
+        task_id: String,
+        /// Reconnect with exponential backoff on disconnect.
+        #[arg(long)]
+        resilient: bool,
+        /// Resume from this event id (gap-free resume works against a2a-rs servers).
+        #[arg(long)]
+        last_event_id: Option<u64>,
+    },
+}
+
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+    tracing_subscriber::fmt()
+        .with_env_filter(
+            tracing_subscriber::EnvFilter::try_from_default_env()
+                .unwrap_or_else(|_| tracing_subscriber::EnvFilter::new("warn")),
+        )
+        .with_writer(std::io::stderr)
+        .init();
+
+    let cli = Cli::parse();
+    let url = cli
+        .url
+        .clone()
+        .context("no agent URL: pass --url/-u or set A2A_URL")?;
+
+    match &cli.command {
+        Command::Card => {
+            let card = a2a_rs::fetch_agent_card(&url)
+                .await
+                .context("fetching agent card")?;
+            emit_card(cli.json, &card)?;
+        }
+
+        Command::Send {
+            text,
+            task_id,
+            session_id,
+            history_length,
+        } => {
+            let transport = build_transport(&cli, &url).await?;
+            let task_id = task_id
+                .clone()
+                .unwrap_or_else(|| uuid::Uuid::new_v4().to_string());
+            let message = Message::user_text(text.clone(), uuid::Uuid::new_v4().to_string());
+            let task = transport
+                .send_task_message(&task_id, &message, session_id.as_deref(), *history_length)
+                .await
+                .context("sending message")?;
+            emit_task(cli.json, &task)?;
+        }
+
+        Command::Get {
+            task_id,
+            history_length,
+        } => {
+            let transport = build_transport(&cli, &url).await?;
+            let task = transport
+                .get_task(task_id, *history_length)
+                .await
+                .context("getting task")?;
+            emit_task(cli.json, &task)?;
+        }
+
+        Command::Cancel { task_id } => {
+            let transport = build_transport(&cli, &url).await?;
+            let task = transport
+                .cancel_task(task_id)
+                .await
+                .context("cancelling task")?;
+            emit_task(cli.json, &task)?;
+        }
+
+        Command::Stream {
+            task_id,
+            resilient,
+            last_event_id,
+        } => {
+            let transport = build_transport(&cli, &url).await?;
+            let mut stream: EventStream = if *resilient {
+                subscribe_resilient(
+                    transport.clone(),
+                    task_id.clone(),
+                    None,
+                    *last_event_id,
+                    RetryPolicy::default(),
+                )
+            } else {
+                let last = last_event_id.map(|id| id.to_string());
+                transport
+                    .subscribe_to_task(task_id, None, last.as_deref())
+                    .await
+                    .context("subscribing to task")?
+            };
+            while let Some(event) = stream.next().await {
+                let event = event.context("stream error")?;
+                emit_event(cli.json, &event)?;
+            }
+        }
+    }
+
+    Ok(())
+}
+
+/// Build a transport from the global args. `card` doesn't need this (it uses the
+/// plain `fetch_agent_card` HTTP GET); everything else drives the `Transport` port.
+async fn build_transport(cli: &Cli, url: &str) -> anyhow::Result<Arc<dyn Transport>> {
+    let transport: Box<dyn Transport> = match cli.transport {
+        TransportChoice::Auto => {
+            if cli.auth.is_some() || cli.timeout.is_some() {
+                tracing::warn!(
+                    "--auth/--timeout are ignored in `auto` transport mode; \
+                     use --transport connectrpc|jsonrpc to apply them"
+                );
+            }
+            a2a_rs::auto_connect(url)
+                .await
+                .context("auto-connecting to agent")?
+        }
+        TransportChoice::Connectrpc => {
+            let mut client = match &cli.auth {
+                Some(token) => HttpClient::with_auth(url.to_string(), token.clone()),
+                None => HttpClient::new(url.to_string()),
+            };
+            if let Some(secs) = cli.timeout {
+                client = client.with_timeout(secs);
+            }
+            Box::new(client)
+        }
+        TransportChoice::Jsonrpc => {
+            let mut client = match &cli.auth {
+                Some(token) => JsonRpcClient::with_auth(url.to_string(), token.clone()),
+                None => JsonRpcClient::new(url.to_string()),
+            };
+            if let Some(secs) = cli.timeout {
+                client = client.with_timeout(secs);
+            }
+            Box::new(client)
+        }
+    };
+    Ok(Arc::from(transport))
+}
+
+// --- output -----------------------------------------------------------------
+//
+// Human output is derived from the serialized (ProtoJSON, camelCase) value with
+// defensive key lookups, so it doesn't couple to the build-time generated field
+// idents. `--json` always prints the authoritative pretty JSON.
+
+fn emit_card(json: bool, card: &AgentCard) -> anyhow::Result<()> {
+    let value = serde_json::to_value(card)?;
+    if json {
+        println!("{}", serde_json::to_string_pretty(&value)?);
+        return Ok(());
+    }
+
+    let s = |key: &str| str_field(&value, key);
+    println!("{} v{}", or_dash(s("name")), or_dash(s("version")));
+    if let Some(desc) = s("description") {
+        println!("  {desc}");
+    }
+    if let Some(ifaces) = array_field(&value, "supportedInterfaces") {
+        println!("  interfaces:");
+        for iface in ifaces {
+            println!(
+                "    - {} {}",
+                or_dash(str_field(iface, "protocolBinding")),
+                or_dash(str_field(iface, "url")),
+            );
+        }
+    }
+    if let Some(skills) = array_field(&value, "skills") {
+        println!("  skills:");
+        for skill in skills {
+            println!(
+                "    - {}: {}",
+                or_dash(str_field(skill, "name")),
+                or_dash(str_field(skill, "description")),
+            );
+        }
+    }
+    Ok(())
+}
+
+fn emit_task(json: bool, task: &Task) -> anyhow::Result<()> {
+    let value = serde_json::to_value(task)?;
+    if json {
+        println!("{}", serde_json::to_string_pretty(&value)?);
+        return Ok(());
+    }
+    println!("task {}", or_dash(str_field(&value, "id")));
+    if let Some(ctx) = str_field(&value, "contextId") {
+        println!("  context: {ctx}");
+    }
+    println!("  state:   {}", or_dash(task_state(&value)));
+    Ok(())
+}
+
+fn emit_event(json: bool, event: &StreamEvent) -> anyhow::Result<()> {
+    let (kind, payload) = match &event.item {
+        StreamItem::Task(t) => ("task", serde_json::to_value(t)?),
+        StreamItem::StatusUpdate(u) => ("status", serde_json::to_value(u)?),
+        StreamItem::ArtifactUpdate(a) => ("artifact", serde_json::to_value(a)?),
+    };
+
+    if json {
+        let envelope = serde_json::json!({
+            "eventId": event.event_id,
+            "type": kind,
+            "payload": payload,
+        });
+        println!("{}", serde_json::to_string(&envelope)?);
+        return Ok(());
+    }
+
+    let id = event
+        .event_id
+        .map(|n| format!("#{n} "))
+        .unwrap_or_default();
+    match kind {
+        "task" => println!(
+            "{id}● task {} [{}]",
+            or_dash(str_field(&payload, "id")),
+            or_dash(task_state(&payload)),
+        ),
+        "status" => println!("{id}◌ status [{}]", or_dash(task_state(&payload))),
+        _ => {
+            let artifact = payload.get("artifact");
+            let name = artifact
+                .and_then(|a| str_field(a, "name"))
+                .or_else(|| artifact.and_then(|a| str_field(a, "artifactId")));
+            println!("{id}▣ artifact {}", or_dash(name));
+        }
+    }
+    Ok(())
+}
+
+// --- small JSON helpers ------------------------------------------------------
+
+fn str_field<'a>(value: &'a Value, key: &str) -> Option<&'a str> {
+    value.get(key).and_then(Value::as_str).filter(|s| !s.is_empty())
+}
+
+fn array_field<'a>(value: &'a Value, key: &str) -> Option<&'a Vec<Value>> {
+    value.get(key).and_then(Value::as_array).filter(|a| !a.is_empty())
+}
+
+/// A task's `status.state`, e.g. `"TASK_STATE_SUBMITTED"`.
+fn task_state(value: &Value) -> Option<&str> {
+    value.get("status").and_then(|s| str_field(s, "state"))
+}
+
+fn or_dash(value: Option<&str>) -> &str {
+    value.unwrap_or("-")
+}


### PR DESCRIPTION
## What

Adds a small **`a2acli`** binary crate that drives the client `Transport` port
from `a2a-rs` directly (not `a2a-client`, which would drag in axum/askama for zero
CLI benefit), plus promotes the `auto_connect` ergonomic helper down into `a2a-rs`
so the CLI and the web client are siblings sharing one entry point. Implements the
0.5 roadmap CLI item.

### `a2acli`
- Commands: `card`, `send`, `get`, `cancel`, `stream` (`--resilient` / `--last-event-id`).
- Endpoint from `A2A_URL` with `--url`/`-u` (alias `--base-url`) override.
- `--transport auto|connectrpc|jsonrpc` (default `auto` = card-driven negotiation,
  ConnectRPC preferred, JSON-RPC 2.0 interop fallback, direct-client fallback on miss).
- `--json` for machine-readable output (one JSON envelope per line for `stream`).
- Output is derived from `serde_json` camelCase values, decoupled from the
  build-time generated field idents.
- Doubles as a manual cross-SDK interop harness (see README).

### `a2a_rs::auto_connect`
- Promotes `WebA2AClient::auto_connect`'s URL-validate → `connect` → direct-client
  fallback into `a2a-rs` (behind the client features), re-exported at the crate root.
- `WebA2AClient::auto_connect` now delegates to it; dropped the now-unused `reqwest`
  dep from `a2a-client`. Malformed URLs now surface as `A2AError::InvalidParams`
  (pre-1.0 clean break; the one call site + test are updated).

## Verification

- `cargo clippy --workspace --all-features -- -D warnings` ✓
- `cargo check -p a2a-rs --no-default-features` ✓ (no feature leak — `auto_connect` is gated)
- New `auto_connect` unit tests + `a2a-web-client` suite ✓
- **End-to-end**: full task lifecycle (`card`/`send`/`get`/`cancel`, human + `--json`,
  auto + explicit transports) against `examples/jsonrpc_server`; and **live SSE
  streaming** against `complex_agent` — `a2acli stream` received status + artifact +
  status events in real time.

## Known limitations / follow-ups (see `TODO.md`)

- **`--auth`/`--timeout` apply to explicit transports only.** The negotiation
  factories build unauthenticated, default-timeout clients, so in `auto` mode these
  flags are ignored (a warning is logged). Threading credentials through
  `TransportFactory` is a tracked follow-up.
- **Agent-card transport mislabel (found while testing).** The `a2a-agents`
  `AgentBuilder` runtime serves ConnectRPC but its card advertises the interface as
  `JSONRPC`, which breaks client auto-negotiation (`--transport connectrpc` works).
  Tracked in `TODO.md` — a framework bug, not a CLI bug.
- ConnectRPC SSE subscriptions don't close on terminal task state (tracked).

🤖 Generated with [Claude Code](https://claude.com/claude-code)