### PR TITLE
feat: OpenRouter/GLM provider, reasoning capture, and live token streaming

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3152,9 +3152,9 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.14"
+version = "0.11.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
+checksum = "4fcb935c5bec503c2f0e306bdd3e58bb9029dcb14fa8d9ac76e3a5256ac0763e"
 dependencies = [
  "bytes",
  "getrandom 0.3.4",

--- a/a2a-agents-common/src/caching/mod.rs
+++ b/a2a-agents-common/src/caching/mod.rs
@@ -15,7 +15,7 @@ use std::time::Duration;
 /// use a2a_agents_common::caching::AgentCache;
 /// use std::time::Duration;
 ///
-/// #[tokio::main]
+/// #[tokio::main(flavor = "current_thread")]
 /// async fn main() {
 ///     let cache = AgentCache::<&'static str, &'static str>::new()
 ///         .with_max_capacity(1000)

--- a/a2a-agents-common/src/llm/gemini.rs
+++ b/a2a-agents-common/src/llm/gemini.rs
@@ -358,6 +358,7 @@ impl LlmProvider for GeminiProvider {
         Ok(LlmResponse {
             content: message_content,
             tool_calls,
+            reasoning: None,
         })
     }
 

--- a/a2a-agents-common/src/llm/mod.rs
+++ b/a2a-agents-common/src/llm/mod.rs
@@ -5,8 +5,10 @@ use serde_json::Value;
 
 pub mod gemini;
 pub mod openai;
+pub mod provider;
 pub mod tool_call;
 
+pub use provider::{LlmSettings, provider_from_env, provider_from_settings};
 pub use tool_call::{PartialToolCall, ToolCallAccumulator};
 
 /// Represents an error returned by an LLM provider.
@@ -108,6 +110,49 @@ impl ChatMessage {
     }
 }
 
+/// How hard a reasoning model should think, when reasoning is requested.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ReasoningEffort {
+    Low,
+    Medium,
+    High,
+}
+
+impl ReasoningEffort {
+    /// The wire token used by OpenRouter's `reasoning.effort`.
+    pub fn as_str(self) -> &'static str {
+        match self {
+            ReasoningEffort::Low => "low",
+            ReasoningEffort::Medium => "medium",
+            ReasoningEffort::High => "high",
+        }
+    }
+}
+
+/// Opt-in reasoning controls for reasoning-capable models (e.g. GLM via
+/// OpenRouter). When set on an [`LlmRequest`], a supporting provider returns its
+/// thinking on a separate channel (surfaced as [`LlmResponse::reasoning`] /
+/// [`LlmStreamEvent::Reasoning`]). Providers that don't support it ignore this.
+#[derive(Debug, Clone, Default)]
+pub struct ReasoningConfig {
+    /// Reasoning effort. Mutually exclusive with `max_tokens` on most providers.
+    pub effort: Option<ReasoningEffort>,
+    /// Hard cap on reasoning tokens.
+    pub max_tokens: Option<u32>,
+    /// Let the model reason internally but omit the reasoning from the response.
+    pub exclude: bool,
+}
+
+impl ReasoningConfig {
+    /// Request reasoning at the given effort level.
+    pub fn effort(effort: ReasoningEffort) -> Self {
+        Self {
+            effort: Some(effort),
+            ..Default::default()
+        }
+    }
+}
+
 /// A request to an LLM provider for chat completion.
 #[derive(Debug, Clone)]
 pub struct LlmRequest {
@@ -116,6 +161,8 @@ pub struct LlmRequest {
     pub temperature: Option<f32>,
     pub max_tokens: Option<u32>,
     pub force_json: bool,
+    /// Opt-in reasoning controls; `None` leaves provider defaults untouched.
+    pub reasoning: Option<ReasoningConfig>,
 }
 
 impl LlmRequest {
@@ -126,7 +173,13 @@ impl LlmRequest {
             temperature: None,
             max_tokens: None,
             force_json: false,
+            reasoning: None,
         }
+    }
+
+    pub fn reasoning(mut self, config: ReasoningConfig) -> Self {
+        self.reasoning = Some(config);
+        self
     }
 
     pub fn temperature(mut self, temp: f32) -> Self {
@@ -155,12 +208,19 @@ impl LlmRequest {
 pub struct LlmResponse {
     pub content: Option<String>,
     pub tool_calls: Option<Vec<ToolCall>>,
+    /// Reasoning-model "thinking" text, when the provider exposes it separately
+    /// from the answer (e.g. OpenRouter's `reasoning`, Zhipu/GLM's
+    /// `reasoning_content`). `None` for providers that don't surface it.
+    pub reasoning: Option<String>,
 }
 
 /// An event emitted during a streaming LLM response.
 #[derive(Debug, Clone)]
 pub enum LlmStreamEvent {
     ContentChunk(String),
+    /// A chunk of reasoning-model "thinking" text, distinct from the answer
+    /// content (e.g. OpenRouter's `reasoning` / Zhipu's `reasoning_content`).
+    Reasoning(String),
     ToolCallChunk {
         id: String,
         name: Option<String>,

--- a/a2a-agents-common/src/llm/openai.rs
+++ b/a2a-agents-common/src/llm/openai.rs
@@ -12,7 +12,14 @@ pub struct OpenAiConfig {
     pub base_url: String,
     pub model: String,
     pub api_key: Option<String>,
+    /// Extra HTTP headers attached to every request. Kept provider-agnostic so
+    /// the OpenAI-compatible adapter carries e.g. OpenRouter's `HTTP-Referer` /
+    /// `X-Title` attribution headers without knowing what they mean.
+    pub extra_headers: Vec<(String, String)>,
 }
+
+/// Default base URL for the OpenRouter API (OpenAI-compatible surface).
+pub const OPENROUTER_BASE_URL: &str = "https://openrouter.ai/api/v1";
 
 impl OpenAiConfig {
     pub fn from_env() -> Result<Self, String> {
@@ -40,7 +47,62 @@ impl OpenAiConfig {
             base_url,
             model,
             api_key,
+            extra_headers: Vec::new(),
         })
+    }
+
+    /// Build an OpenRouter config (OpenAI-compatible) from explicit values.
+    ///
+    /// `base_url` defaults to [`OPENROUTER_BASE_URL`] when `None`. The optional
+    /// `http_referer` / `x_title` become OpenRouter attribution headers and are
+    /// only sent when provided.
+    pub fn openrouter(
+        api_key: String,
+        model: String,
+        base_url: Option<String>,
+        http_referer: Option<String>,
+        x_title: Option<String>,
+    ) -> Self {
+        let mut extra_headers = Vec::new();
+        if let Some(referer) = http_referer {
+            extra_headers.push(("HTTP-Referer".to_string(), referer));
+        }
+        if let Some(title) = x_title {
+            extra_headers.push(("X-Title".to_string(), title));
+        }
+        Self {
+            base_url: base_url.unwrap_or_else(|| OPENROUTER_BASE_URL.to_string()),
+            model,
+            api_key: Some(api_key),
+            extra_headers,
+        }
+    }
+
+    /// Read OpenRouter config from the environment.
+    ///
+    /// `OPENROUTER_API_KEY` is required; the rest fall back to defaults:
+    /// `OPENROUTER_MODEL` (`z-ai/glm-4.6`), `OPENROUTER_API_BASE_URL`
+    /// ([`OPENROUTER_BASE_URL`]), plus optional `OPENROUTER_HTTP_REFERER` /
+    /// `OPENROUTER_X_TITLE` attribution headers.
+    pub fn openrouter_from_env() -> Result<Self, String> {
+        let api_key = env::var("OPENROUTER_API_KEY")
+            .ok()
+            .map(|k| k.trim().to_string())
+            .filter(|k| !k.is_empty())
+            .ok_or_else(|| "OPENROUTER_API_KEY environment variable is required".to_string())?;
+
+        let model = env::var("OPENROUTER_MODEL").unwrap_or_else(|_| "z-ai/glm-4.6".to_string());
+        let base_url = env::var("OPENROUTER_API_BASE_URL").ok();
+        let http_referer = env::var("OPENROUTER_HTTP_REFERER").ok();
+        let x_title = env::var("OPENROUTER_X_TITLE").ok();
+
+        Ok(Self::openrouter(
+            api_key,
+            model,
+            base_url,
+            http_referer,
+            x_title,
+        ))
     }
 }
 
@@ -64,6 +126,34 @@ struct OpenAiChatRequest {
     tools: Option<Vec<OpenAiTool>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     stream: Option<bool>,
+    /// OpenRouter's unified reasoning control. Only sent when the caller opts in
+    /// (skipped otherwise so plain OpenAI requests are unaffected).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    reasoning: Option<OpenRouterReasoning>,
+}
+
+/// OpenRouter's `reasoning` request object (see
+/// <https://openrouter.ai/docs/use-cases/reasoning-tokens>).
+#[derive(Debug, Serialize)]
+struct OpenRouterReasoning {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    effort: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    max_tokens: Option<u32>,
+    #[serde(skip_serializing_if = "std::ops::Not::not")]
+    exclude: bool,
+    enabled: bool,
+}
+
+impl From<super::ReasoningConfig> for OpenRouterReasoning {
+    fn from(c: super::ReasoningConfig) -> Self {
+        Self {
+            effort: c.effort.map(|e| e.as_str().to_string()),
+            max_tokens: c.max_tokens,
+            exclude: c.exclude,
+            enabled: true,
+        }
+    }
 }
 
 #[derive(Debug, Serialize)]
@@ -91,6 +181,13 @@ struct OpenAiChatMessage {
     tool_call_id: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     name: Option<String>,
+    /// Reasoning-model thinking, as normalized by OpenRouter. Response-only.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    reasoning: Option<String>,
+    /// Raw Zhipu/GLM reasoning field (used when not going through OpenRouter's
+    /// normalization). Response-only.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    reasoning_content: Option<String>,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -130,6 +227,10 @@ struct StreamChoice {
 #[derive(Debug, Deserialize)]
 struct StreamDelta {
     content: Option<String>,
+    #[serde(default)]
+    reasoning: Option<String>,
+    #[serde(default)]
+    reasoning_content: Option<String>,
     tool_calls: Option<Vec<StreamToolCall>>,
 }
 
@@ -205,6 +306,8 @@ impl LlmProvider for OpenAiProvider {
                 }),
                 tool_call_id: msg.tool_call_id,
                 name: msg.name,
+                reasoning: None,
+                reasoning_content: None,
             })
             .collect();
 
@@ -230,6 +333,7 @@ impl LlmProvider for OpenAiProvider {
             response_format,
             tools,
             stream: None,
+            reasoning: request.reasoning.map(Into::into),
         };
 
         debug!(
@@ -243,6 +347,10 @@ impl LlmProvider for OpenAiProvider {
 
         if let Some(ref api_key) = self.config.api_key {
             req_builder = req_builder.bearer_auth(api_key);
+        }
+
+        for (name, value) in &self.config.extra_headers {
+            req_builder = req_builder.header(name.as_str(), value.as_str());
         }
 
         let response = req_builder.send().await.map_err(|e| {
@@ -285,16 +393,22 @@ impl LlmProvider for OpenAiProvider {
         });
 
         let message_content = choice.message.content;
+        let reasoning = choice
+            .message
+            .reasoning
+            .or(choice.message.reasoning_content);
 
         info!(
             has_content = message_content.is_some(),
             has_tools = tool_calls.is_some(),
+            has_reasoning = reasoning.is_some(),
             "Received chat completion response"
         );
 
         Ok(LlmResponse {
             content: message_content,
             tool_calls,
+            reasoning,
         })
     }
 
@@ -338,6 +452,8 @@ impl LlmProvider for OpenAiProvider {
                 }),
                 tool_call_id: msg.tool_call_id,
                 name: msg.name,
+                reasoning: None,
+                reasoning_content: None,
             })
             .collect();
 
@@ -363,6 +479,7 @@ impl LlmProvider for OpenAiProvider {
             response_format,
             tools,
             stream: Some(true),
+            reasoning: request.reasoning.map(Into::into),
         };
 
         debug!(
@@ -375,6 +492,10 @@ impl LlmProvider for OpenAiProvider {
 
         if let Some(ref api_key) = self.config.api_key {
             req_builder = req_builder.bearer_auth(api_key);
+        }
+
+        for (name, value) in &self.config.extra_headers {
+            req_builder = req_builder.header(name.as_str(), value.as_str());
         }
 
         let response = req_builder.send().await.map_err(|e| {
@@ -433,6 +554,12 @@ impl LlmProvider for OpenAiProvider {
                 };
 
                 for choice in chunk.choices {
+                    if let Some(reasoning) = choice.delta.reasoning.or(choice.delta.reasoning_content) {
+                        if !reasoning.is_empty() {
+                            yield super::LlmStreamEvent::Reasoning(reasoning);
+                        }
+                    }
+
                     if let Some(content) = choice.delta.content {
                         if !content.is_empty() {
                             yield super::LlmStreamEvent::ContentChunk(content);

--- a/a2a-agents-common/src/llm/provider.rs
+++ b/a2a-agents-common/src/llm/provider.rs
@@ -1,0 +1,161 @@
+//! Centralized [`LlmProvider`] selection.
+//!
+//! This is the single place agents pick a concrete LLM provider, replacing the
+//! ad-hoc `GeminiProvider::from_env()` / `OpenAiProvider::from_env()` cascades
+//! that used to be copy-pasted across handlers, examples, and the CLI.
+//!
+//! Two entry points:
+//! - [`provider_from_env`] — env-driven selection (OpenRouter → Gemini → OpenAI).
+//! - [`provider_from_settings`] — config-driven selection from [`LlmSettings`].
+//!
+//! Settings are expressed with this crate's own [`LlmSettings`] type rather than
+//! a host's config struct so the helper takes no dependency on `a2a-agents`
+//! (which would be circular).
+
+use std::sync::Arc;
+
+use tracing::{info, warn};
+
+use super::{
+    LlmProvider,
+    gemini::{GeminiConfig, GeminiProvider},
+    openai::{OpenAiConfig, OpenAiProvider},
+};
+
+/// Provider-agnostic LLM settings sourced from a host's configuration
+/// (TOML, CLI flags, etc.). Mirrors the fields a host typically exposes.
+#[derive(Debug, Clone, Default)]
+pub struct LlmSettings {
+    /// Provider selector: `"openrouter"`, `"openai"`, or `"gemini"`.
+    pub provider: String,
+    /// API key. May be omitted for `"openrouter"`/`"openai"` if the matching
+    /// env var is set instead.
+    pub api_key: Option<String>,
+    /// Model identifier. Provider-specific default applied when `None`.
+    pub model: Option<String>,
+    /// Base URL override. Provider-specific default applied when `None`.
+    pub base_url: Option<String>,
+    /// OpenRouter `HTTP-Referer` attribution header (ignored by other providers).
+    pub http_referer: Option<String>,
+    /// OpenRouter `X-Title` attribution header (ignored by other providers).
+    pub x_title: Option<String>,
+}
+
+fn env_set(key: &str) -> bool {
+    std::env::var(key)
+        .ok()
+        .map(|v| !v.trim().is_empty())
+        .unwrap_or(false)
+}
+
+/// Select a provider from the environment.
+///
+/// Preference order, each gated on a *present* key so an unconfigured agent
+/// degrades to its non-LLM fallback instead of silently picking a dead provider:
+///
+/// 1. **OpenRouter** when `OPENROUTER_API_KEY` is set.
+/// 2. **Gemini** when `GEMINI_API_KEY` is set.
+/// 3. **OpenAI-compatible** when any of `OPENAI_API_KEY`, `AI_API_KEY`,
+///    `OPENAI_API_BASE_URL`, or `AI_API_BASE_URL` is set (covers local Ollama).
+///
+/// Returns `None` when nothing is configured.
+pub fn provider_from_env() -> Option<Arc<dyn LlmProvider>> {
+    if env_set("OPENROUTER_API_KEY") {
+        match OpenAiConfig::openrouter_from_env() {
+            Ok(config) => {
+                info!(model = %config.model, "🤖 LLM: OpenRouter (tool-calling enabled)");
+                return Some(Arc::new(OpenAiProvider::new(config)));
+            }
+            Err(e) => warn!("OPENROUTER_API_KEY set but config failed: {e}"),
+        }
+    }
+
+    if env_set("GEMINI_API_KEY") {
+        match GeminiProvider::from_env() {
+            Ok(gemini) => {
+                info!("🤖 LLM: Gemini (tool-calling enabled)");
+                return Some(Arc::new(gemini));
+            }
+            Err(e) => warn!("GEMINI_API_KEY set but config failed: {e}"),
+        }
+    }
+
+    if env_set("OPENAI_API_KEY")
+        || env_set("AI_API_KEY")
+        || env_set("OPENAI_API_BASE_URL")
+        || env_set("AI_API_BASE_URL")
+    {
+        match OpenAiProvider::from_env() {
+            Ok(openai) => {
+                info!("🤖 LLM: OpenAI-compatible (tool-calling enabled)");
+                return Some(Arc::new(openai));
+            }
+            Err(e) => warn!("OpenAI config failed: {e}"),
+        }
+    }
+
+    info!("🤖 LLM: none configured — host should use its non-LLM fallback");
+    None
+}
+
+/// Build a provider from explicit [`LlmSettings`].
+///
+/// Errors on an unknown provider string or a missing required API key (the
+/// `"openrouter"` key may instead come from `OPENROUTER_API_KEY`).
+pub fn provider_from_settings(settings: &LlmSettings) -> Result<Arc<dyn LlmProvider>, String> {
+    match settings.provider.as_str() {
+        "openrouter" => {
+            let api_key = settings
+                .api_key
+                .clone()
+                .or_else(|| std::env::var("OPENROUTER_API_KEY").ok())
+                .map(|k| k.trim().to_string())
+                .filter(|k| !k.is_empty())
+                .ok_or_else(|| {
+                    "openrouter provider requires api_key (config) or OPENROUTER_API_KEY (env)"
+                        .to_string()
+                })?;
+            let model = settings
+                .model
+                .clone()
+                .unwrap_or_else(|| "z-ai/glm-4.6".to_string());
+            let config = OpenAiConfig::openrouter(
+                api_key,
+                model,
+                settings.base_url.clone(),
+                settings.http_referer.clone(),
+                settings.x_title.clone(),
+            );
+            Ok(Arc::new(OpenAiProvider::new(config)))
+        }
+        "openai" => {
+            let config = OpenAiConfig {
+                base_url: settings
+                    .base_url
+                    .clone()
+                    .unwrap_or_else(|| "https://api.openai.com/v1".to_string()),
+                model: settings
+                    .model
+                    .clone()
+                    .unwrap_or_else(|| "gpt-4o-mini".to_string()),
+                api_key: settings.api_key.clone(),
+                extra_headers: Vec::new(),
+            };
+            Ok(Arc::new(OpenAiProvider::new(config)))
+        }
+        "gemini" => {
+            let config = GeminiConfig {
+                base_url: settings.base_url.clone().unwrap_or_else(|| {
+                    "https://generativelanguage.googleapis.com/v1beta/models".to_string()
+                }),
+                api_key: settings.api_key.clone().unwrap_or_default(),
+                model: settings
+                    .model
+                    .clone()
+                    .unwrap_or_else(|| "gemini-1.5-pro".to_string()),
+            };
+            Ok(Arc::new(GeminiProvider::new(config)))
+        }
+        other => Err(format!("unsupported LLM provider: {other}")),
+    }
+}

--- a/a2a-agents/bin/a2a.rs
+++ b/a2a-agents/bin/a2a.rs
@@ -123,26 +123,27 @@ async fn main() -> anyhow::Result<()> {
                         AutoStorage::from_config(&builder.config().server.storage).await?;
 
                     // Initialize LLM from config if provided, else from the env.
-                    let llm_provider: Option<Arc<dyn LlmProvider>> = match &builder.config().llm {
-                        Some(llm_config) => {
-                            info!(
-                                "Loading LLM configuration from TOML (provider: {})",
-                                llm_config.provider
-                            );
-                            let settings = LlmSettings {
-                                provider: llm_config.provider.clone(),
-                                api_key: llm_config.api_key.clone(),
-                                model: llm_config.model.clone(),
-                                base_url: llm_config.base_url.clone(),
-                                http_referer: llm_config.http_referer.clone(),
-                                x_title: llm_config.x_title.clone(),
-                            };
-                            Some(provider_from_settings(&settings).map_err(|e| {
-                                anyhow::anyhow!("invalid LLM configuration: {e}")
-                            })?)
-                        }
-                        None => provider_from_env(),
-                    };
+                    let llm_provider: Option<Arc<dyn LlmProvider>> =
+                        match &builder.config().llm {
+                            Some(llm_config) => {
+                                info!(
+                                    "Loading LLM configuration from TOML (provider: {})",
+                                    llm_config.provider
+                                );
+                                let settings = LlmSettings {
+                                    provider: llm_config.provider.clone(),
+                                    api_key: llm_config.api_key.clone(),
+                                    model: llm_config.model.clone(),
+                                    base_url: llm_config.base_url.clone(),
+                                    http_referer: llm_config.http_referer.clone(),
+                                    x_title: llm_config.x_title.clone(),
+                                };
+                                Some(provider_from_settings(&settings).map_err(|e| {
+                                    anyhow::anyhow!("invalid LLM configuration: {e}")
+                                })?)
+                            }
+                            None => provider_from_env(),
+                        };
 
                     let streaming = InMemoryStreamingHandler::new();
                     let push = storage.push_notifier();

--- a/a2a-agents/bin/a2a.rs
+++ b/a2a-agents/bin/a2a.rs
@@ -7,9 +7,7 @@
 use a2a_agents::agents::reimbursement::ReimbursementHandler;
 use a2a_agents::core::AgentBuilder;
 use a2a_agents::core::builder::AutoStorage;
-use a2a_agents_common::llm::LlmProvider;
-use a2a_agents_common::llm::gemini::{GeminiConfig, GeminiProvider};
-use a2a_agents_common::llm::openai::{OpenAiConfig, OpenAiProvider};
+use a2a_agents_common::llm::{LlmProvider, LlmSettings, provider_from_env, provider_from_settings};
 
 use a2a_rs::{
     InMemoryStreamingHandler,
@@ -124,54 +122,27 @@ async fn main() -> anyhow::Result<()> {
                     let storage =
                         AutoStorage::from_config(&builder.config().server.storage).await?;
 
-                    // Initialize LLM from config if provided
-                    let mut llm_provider: Option<Arc<dyn LlmProvider>> = None;
-                    if let Some(llm_config) = &builder.config().llm {
-                        info!(
-                            "Loading LLM configuration from TOML (provider: {})",
-                            llm_config.provider
-                        );
-                        match llm_config.provider.as_str() {
-                            "openai" => {
-                                let openai_config = OpenAiConfig {
-                                    base_url: llm_config
-                                        .base_url
-                                        .clone()
-                                        .unwrap_or_else(|| "https://api.openai.com/v1".to_string()),
-                                    model: llm_config
-                                        .model
-                                        .clone()
-                                        .unwrap_or_else(|| "gpt-4o-mini".to_string()),
-                                    api_key: llm_config.api_key.clone(),
-                                };
-                                llm_provider = Some(Arc::new(OpenAiProvider::new(openai_config)));
-                            }
-                            "gemini" => {
-                                let gemini_config = GeminiConfig {
-                                    base_url: llm_config.base_url.clone().unwrap_or_else(|| "https://generativelanguage.googleapis.com/v1beta/models".to_string()),
-                                    api_key: llm_config.api_key.clone().unwrap_or_default(),
-                                    model: llm_config.model.clone().unwrap_or_else(|| "gemini-1.5-pro".to_string()),
-                                };
-                                llm_provider = Some(Arc::new(GeminiProvider::new(gemini_config)));
-                            }
-                            other => {
-                                warn!("Unsupported LLM provider in config: {}", other);
-                            }
-                        }
-                    } else {
-                        // Fallback to environment variables if no config is provided
-                        if let Ok(gemini) = GeminiProvider::from_env() {
-                            info!("Gemini client initialized successfully from environment");
-                            llm_provider = Some(Arc::new(gemini));
-                        } else if let Ok(openai) = OpenAiProvider::from_env() {
-                            info!("OpenAI client initialized successfully from environment");
-                            llm_provider = Some(Arc::new(openai));
-                        } else {
-                            warn!(
-                                "Failed to initialize any AI client. Conversational features will be disabled."
+                    // Initialize LLM from config if provided, else from the env.
+                    let llm_provider: Option<Arc<dyn LlmProvider>> = match &builder.config().llm {
+                        Some(llm_config) => {
+                            info!(
+                                "Loading LLM configuration from TOML (provider: {})",
+                                llm_config.provider
                             );
+                            let settings = LlmSettings {
+                                provider: llm_config.provider.clone(),
+                                api_key: llm_config.api_key.clone(),
+                                model: llm_config.model.clone(),
+                                base_url: llm_config.base_url.clone(),
+                                http_referer: llm_config.http_referer.clone(),
+                                x_title: llm_config.x_title.clone(),
+                            };
+                            Some(provider_from_settings(&settings).map_err(|e| {
+                                anyhow::anyhow!("invalid LLM configuration: {e}")
+                            })?)
                         }
-                    }
+                        None => provider_from_env(),
+                    };
 
                     let streaming = InMemoryStreamingHandler::new();
                     let push = storage.push_notifier();

--- a/a2a-agents/examples/complex_agent.rs
+++ b/a2a-agents/examples/complex_agent.rs
@@ -297,8 +297,14 @@ impl ResearchAssistantHandler {
 
     /// Push a discrete progress line (status, tool calls) to SSE subscribers.
     async fn stream_progress(&self, task_id: &str, context_id: &str, text: &str) {
-        self.stream_artifact(task_id, context_id, &format!("progress-{task_id}"), "progress", text)
-            .await;
+        self.stream_artifact(
+            task_id,
+            context_id,
+            &format!("progress-{task_id}"),
+            "progress",
+            text,
+        )
+        .await;
     }
 
     /// LLM path: let the model pick tools, execute them via the bridge, loop
@@ -350,15 +356,25 @@ impl ResearchAssistantHandler {
                 match event.map_err(|e| A2AError::Internal(format!("LLM stream error: {e}")))? {
                     LlmStreamEvent::Reasoning(chunk) => {
                         reasoning.push_str(&chunk);
-                        self.stream_artifact(task_id, context_id, &thinking_id, "AI Thinking...", &chunk)
-                            .await;
+                        self.stream_artifact(
+                            task_id,
+                            context_id,
+                            &thinking_id,
+                            "AI Thinking...",
+                            &chunk,
+                        )
+                        .await;
                     }
                     LlmStreamEvent::ContentChunk(chunk) => {
                         content.push_str(&chunk);
                         self.stream_artifact(task_id, context_id, &answer_id, "AI Answer", &chunk)
                             .await;
                     }
-                    LlmStreamEvent::ToolCallChunk { id, name, arguments } => {
+                    LlmStreamEvent::ToolCallChunk {
+                        id,
+                        name,
+                        arguments,
+                    } => {
                         calls.push(&id, name.as_deref(), &arguments);
                     }
                     LlmStreamEvent::ToolCall(call) => {
@@ -398,8 +414,12 @@ impl ResearchAssistantHandler {
                     .execute_llm_tool_call(task_id, call)
                     .await
                     .map_err(|e| e.to_a2a_error())?;
-                self.stream_progress(task_id, context_id, &format!("✅ `{}` → {result}", call.name))
-                    .await;
+                self.stream_progress(
+                    task_id,
+                    context_id,
+                    &format!("✅ `{}` → {result}", call.name),
+                )
+                .await;
                 messages.push(ChatMessage::tool_result(
                     call.id.clone(),
                     call.name.clone(),
@@ -541,7 +561,10 @@ impl AsyncMessageHandler for ResearchAssistantHandler {
                 .context_id(context_id.clone())
                 .build();
 
-            if let Err(e) = handler.update_and_broadcast(&id, state, Some(response)).await {
+            if let Err(e) = handler
+                .update_and_broadcast(&id, state, Some(response))
+                .await
+            {
                 tracing::warn!("failed to finalize task {task_id}: {e}");
             }
         });

--- a/a2a-agents/examples/complex_agent.rs
+++ b/a2a-agents/examples/complex_agent.rs
@@ -42,7 +42,8 @@ use std::sync::Arc;
 
 use a2a_agents::core::AgentBuilder;
 use a2a_agents_common::llm::{
-    ChatMessage, LlmProvider, LlmRequest, MessageRole, ToolCall, ToolDefinition,
+    ChatMessage, LlmProvider, LlmRequest, LlmStreamEvent, MessageRole, ReasoningConfig,
+    ReasoningEffort, ToolCall, ToolCallAccumulator, ToolDefinition,
 };
 use a2a_mcp::McpToA2ABridge;
 use a2a_rs::Artifact;
@@ -254,11 +255,22 @@ impl ResearchAssistantHandler {
         }
     }
 
-    /// Push an incremental progress artifact to any SSE subscriber.
-    async fn stream_progress(&self, task_id: &str, context_id: &str, text: &str) {
+    /// Broadcast one appending chunk of a named artifact to SSE subscribers.
+    ///
+    /// Chunks sharing an `artifact_id` accumulate client-side (the UI appends
+    /// `append: true` parts into the same bubble), so token-by-token content and
+    /// reasoning render live.
+    async fn stream_artifact(
+        &self,
+        task_id: &str,
+        context_id: &str,
+        artifact_id: &str,
+        name: &str,
+        text: &str,
+    ) {
         let artifact = Artifact {
-            artifact_id: format!("progress-{task_id}"),
-            name: "progress".to_string(),
+            artifact_id: artifact_id.to_string(),
+            name: name.to_string(),
             description: String::new(),
             parts: vec![Part::text(text.to_string())],
             metadata: ::buffa::MessageField::none(),
@@ -279,12 +291,20 @@ impl ResearchAssistantHandler {
             .broadcast_artifact_update(task_id, event)
             .await
         {
-            tracing::warn!("failed to broadcast progress: {e}");
+            tracing::warn!("failed to broadcast artifact: {e}");
         }
     }
 
+    /// Push a discrete progress line (status, tool calls) to SSE subscribers.
+    async fn stream_progress(&self, task_id: &str, context_id: &str, text: &str) {
+        self.stream_artifact(task_id, context_id, &format!("progress-{task_id}"), "progress", text)
+            .await;
+    }
+
     /// LLM path: let the model pick tools, execute them via the bridge, loop
-    /// until it answers in prose.
+    /// until it answers in prose. Each round is **streamed** — reasoning and
+    /// answer tokens are broadcast to SSE subscribers as they arrive, so the UI
+    /// fills in live instead of stalling for the whole completion.
     async fn run_with_llm(
         &self,
         llm: &dyn LlmProvider,
@@ -292,60 +312,99 @@ impl ResearchAssistantHandler {
         context_id: &str,
         user_text: &str,
     ) -> Result<String, A2AError> {
+        use futures::StreamExt;
+
         let tools: Vec<ToolDefinition> = self.bridge.get_llm_tools();
         let mut messages = vec![
             ChatMessage::system(SYSTEM_PROMPT),
             ChatMessage::user(user_text),
         ];
+        // GLM and other OpenRouter reasoning models only return their thinking on
+        // a separate channel when asked. Gate on the same signal
+        // `provider_from_env` uses to pick OpenRouter, so a plain-OpenAI run
+        // never sends the (OpenRouter-specific) `reasoning` param.
+        let reasoning_enabled = std::env::var("OPENROUTER_API_KEY").is_ok();
 
-        for _round in 0..MAX_TOOL_ROUNDS {
+        for round in 0..MAX_TOOL_ROUNDS {
             let mut request = LlmRequest::new(messages.clone()).temperature(0.2);
             if !tools.is_empty() {
                 request = request.tools(tools.clone());
             }
+            if reasoning_enabled {
+                request = request.reasoning(ReasoningConfig::effort(ReasoningEffort::High));
+            }
 
-            let response = llm
-                .chat_completion(request)
+            let mut stream = llm
+                .chat_completion_stream(request)
                 .await
                 .map_err(|e| A2AError::Internal(format!("LLM error: {e}")))?;
 
-            match response.tool_calls {
-                Some(calls) if !calls.is_empty() => {
-                    // Record the assistant turn that requested the tools…
-                    messages.push(ChatMessage {
-                        role: MessageRole::Assistant,
-                        content: response.content.clone(),
-                        tool_calls: Some(calls.clone()),
-                        tool_call_id: None,
-                        name: None,
-                    });
-                    // …then execute each tool against MCP and feed results back.
-                    for call in &calls {
-                        self.stream_progress(
-                            task_id,
-                            context_id,
-                            &format!("🛠️ calling `{}`({})", call.name, call.arguments),
-                        )
-                        .await;
-                        let result = self
-                            .bridge
-                            .execute_llm_tool_call(task_id, call)
-                            .await
-                            .map_err(|e| e.to_a2a_error())?;
-                        self.stream_progress(
-                            task_id,
-                            context_id,
-                            &format!("✅ `{}` → {result}", call.name),
-                        )
-                        .await;
-                        messages.push(ChatMessage::tool_result(
-                            call.id.clone(),
-                            call.name.clone(),
-                            result,
-                        ));
+            // Stable per-round ids so chunks accumulate into one bubble each.
+            let thinking_id = format!("thinking-{task_id}-{round}");
+            let answer_id = format!("answer-{task_id}-{round}");
+            let mut content = String::new();
+            let mut reasoning = String::new();
+            let mut calls = ToolCallAccumulator::new();
+
+            while let Some(event) = stream.next().await {
+                match event.map_err(|e| A2AError::Internal(format!("LLM stream error: {e}")))? {
+                    LlmStreamEvent::Reasoning(chunk) => {
+                        reasoning.push_str(&chunk);
+                        self.stream_artifact(task_id, context_id, &thinking_id, "AI Thinking...", &chunk)
+                            .await;
+                    }
+                    LlmStreamEvent::ContentChunk(chunk) => {
+                        content.push_str(&chunk);
+                        self.stream_artifact(task_id, context_id, &answer_id, "AI Answer", &chunk)
+                            .await;
+                    }
+                    LlmStreamEvent::ToolCallChunk { id, name, arguments } => {
+                        calls.push(&id, name.as_deref(), &arguments);
+                    }
+                    LlmStreamEvent::ToolCall(call) => {
+                        calls.finalize(call);
                     }
                 }
-                _ => return Ok(response.content.unwrap_or_default()),
+            }
+
+            if !reasoning.trim().is_empty() {
+                let preview: String = reasoning.chars().take(280).collect();
+                tracing::info!(has_reasoning = true, "💭 reasoning: {preview}");
+            }
+
+            let calls = calls.drain_completed();
+            if calls.is_empty() {
+                return Ok(content);
+            }
+
+            // Record the assistant turn that requested the tools…
+            messages.push(ChatMessage {
+                role: MessageRole::Assistant,
+                content: (!content.is_empty()).then_some(content),
+                tool_calls: Some(calls.clone()),
+                tool_call_id: None,
+                name: None,
+            });
+            // …then execute each tool against MCP and feed results back.
+            for call in &calls {
+                self.stream_progress(
+                    task_id,
+                    context_id,
+                    &format!("🛠️ calling `{}`({})", call.name, call.arguments),
+                )
+                .await;
+                let result = self
+                    .bridge
+                    .execute_llm_tool_call(task_id, call)
+                    .await
+                    .map_err(|e| e.to_a2a_error())?;
+                self.stream_progress(task_id, context_id, &format!("✅ `{}` → {result}", call.name))
+                    .await;
+                messages.push(ChatMessage::tool_result(
+                    call.id.clone(),
+                    call.name.clone(),
+                    result,
+                ));
             }
         }
         Ok("I couldn't converge on an answer within the tool-call budget.".to_string())
@@ -439,37 +498,55 @@ impl AsyncMessageHandler for ResearchAssistantHandler {
         }
         let context_id = self.lifecycle.get(&id, Some(1)).await?.context_id.clone();
 
-        // Record the user's message and move to Working — broadcast both.
-        self.update_and_broadcast(&id, TaskState::Working, Some(message.clone()))
+        // Record the user's message and move to Working — broadcast both. The
+        // returned `Working` task is what the unary caller gets back immediately.
+        let working = self
+            .update_and_broadcast(&id, TaskState::Working, Some(message.clone()))
             .await?;
-        self.stream_progress(task_id, &context_id, "🔎 Analyzing your request…")
-            .await;
 
+        // Run the LLM/tool loop on a background task so the unary `send` returns
+        // `Working` now and SSE subscribers watch the 💭/🛠️ artifacts and the
+        // final status arrive live (otherwise the synchronous handler would have
+        // finished the task before a client could subscribe).
+        let handler = self.clone();
+        let task_id = task_id.to_string();
         let user_text = extract_text(message);
-        let outcome = match &self.llm {
-            Some(llm) => {
-                self.run_with_llm(llm.as_ref(), task_id, &context_id, &user_text)
-                    .await
+        tokio::spawn(async move {
+            handler
+                .stream_progress(&task_id, &context_id, "🔎 Analyzing your request…")
+                .await;
+
+            let outcome = match &handler.llm {
+                Some(llm) => {
+                    handler
+                        .run_with_llm(llm.as_ref(), &task_id, &context_id, &user_text)
+                        .await
+                }
+                None => {
+                    handler
+                        .run_rule_based(&task_id, &context_id, &user_text)
+                        .await
+                }
+            };
+
+            let (state, reply) = match outcome {
+                Ok(text) => (TaskState::Completed, text),
+                Err(e) => (TaskState::Failed, format!("Sorry — I hit an error: {e}")),
+            };
+
+            let response = Message::builder()
+                .role(Role::Agent)
+                .parts(vec![Part::text(reply)])
+                .message_id(uuid::Uuid::new_v4().to_string())
+                .context_id(context_id.clone())
+                .build();
+
+            if let Err(e) = handler.update_and_broadcast(&id, state, Some(response)).await {
+                tracing::warn!("failed to finalize task {task_id}: {e}");
             }
-            None => self.run_rule_based(task_id, &context_id, &user_text).await,
-        };
+        });
 
-        let (state, reply) = match outcome {
-            Ok(text) => (TaskState::Completed, text),
-            Err(e) => (TaskState::Failed, format!("Sorry — I hit an error: {e}")),
-        };
-
-        let response = Message::builder()
-            .role(Role::Agent)
-            .parts(vec![Part::text(reply)])
-            .message_id(uuid::Uuid::new_v4().to_string())
-            .context_id(context_id)
-            .build();
-
-        let final_task = self
-            .update_and_broadcast(&id, state, Some(response))
-            .await?;
-        Ok(final_task)
+        Ok(working)
     }
 
     async fn validate_message(&self, message: &Message) -> Result<(), A2AError> {
@@ -513,17 +590,9 @@ fn parse_two_numbers(text: &str) -> Option<(f64, f64)> {
 }
 
 fn load_llm() -> Option<Arc<dyn LlmProvider>> {
-    use a2a_agents_common::llm::{gemini::GeminiProvider, openai::OpenAiProvider};
-    if let Ok(gemini) = GeminiProvider::from_env() {
-        tracing::info!("🤖 LLM: Gemini (tool-calling enabled)");
-        return Some(Arc::new(gemini));
-    }
-    if let Ok(openai) = OpenAiProvider::from_env() {
-        tracing::info!("🤖 LLM: OpenAI (tool-calling enabled)");
-        return Some(Arc::new(openai));
-    }
-    tracing::info!("🤖 LLM: none configured — using rule-based fallback");
-    None
+    // Centralized selection (OpenRouter → Gemini → OpenAI). With no key set this
+    // returns None and the handler falls back to the rule-based router.
+    a2a_agents_common::llm::provider_from_env()
 }
 
 // ---------------------------------------------------------------------------

--- a/a2a-agents/src/agents/reimbursement/handler.rs
+++ b/a2a-agents/src/agents/reimbursement/handler.rs
@@ -139,19 +139,9 @@ impl ReimbursementHandler {
         streaming: impl a2a_rs::port::AsyncStreamingHandler + 'static,
         push_notifier: impl a2a_rs::port::AsyncPushNotifier + 'static,
     ) -> Self {
-        // Try to initialize AI client from environment
-        let llm_provider: Option<Arc<dyn LlmProvider>> = if let Ok(gemini) =
-            a2a_agents_common::llm::gemini::GeminiProvider::from_env()
-        {
-            info!("Gemini client initialized successfully");
-            Some(Arc::new(gemini))
-        } else if let Ok(openai) = a2a_agents_common::llm::openai::OpenAiProvider::from_env() {
-            info!("OpenAI client initialized successfully");
-            Some(Arc::new(openai))
-        } else {
-            warn!("Failed to initialize any AI client. Conversational features will be disabled.");
-            None
-        };
+        // Initialize an AI client from the environment (OpenRouter → Gemini →
+        // OpenAI). `None` disables conversational features.
+        let llm_provider = a2a_agents_common::llm::provider_from_env();
 
         Self::with_llm(task_lifecycle, streaming, push_notifier, llm_provider)
     }
@@ -536,6 +526,35 @@ Example response when asking for info:
                     };
 
                     tool_calls.finalize(call);
+
+                    let _ = self
+                        .streaming
+                        .broadcast_artifact_update(task_id, update_event)
+                        .await;
+                }
+                Ok(a2a_agents_common::llm::LlmStreamEvent::Reasoning(chunk)) => {
+                    // Reasoning-model thinking: surface it as a distinct artifact
+                    // but keep it OUT of `ai_response` — the request forces JSON,
+                    // and reasoning text would corrupt the parsed answer.
+                    let artifact = Artifact {
+                        artifact_id: artifact_id.clone(),
+                        name: "AI Thinking...".to_string(),
+                        description: String::new(),
+                        parts: vec![Part::text(chunk)],
+                        metadata: buffa::MessageField::none(),
+                        extensions: Vec::new(),
+                        ..Default::default()
+                    };
+
+                    let update_event = a2a_rs::domain::TaskArtifactUpdateEvent {
+                        task_id: task_id.to_string(),
+                        context_id: current_message.context_id.clone(),
+                        kind: "artifact-update".to_string(),
+                        artifact,
+                        append: Some(true),
+                        last_chunk: Some(false),
+                        metadata: None,
+                    };
 
                     let _ = self
                         .streaming

--- a/a2a-agents/src/core/config.rs
+++ b/a2a-agents/src/core/config.rs
@@ -45,7 +45,7 @@ pub struct AgentConfig {
 /// LLM Configuration
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct LlmConfig {
-    /// LLM Provider (e.g. "openai", "gemini")
+    /// LLM Provider (e.g. "openrouter", "openai", "gemini")
     pub provider: String,
     /// API key for the LLM
     pub api_key: Option<String>,
@@ -53,6 +53,12 @@ pub struct LlmConfig {
     pub model: Option<String>,
     /// Base URL (for providers like openai that support local LLMs like ollama)
     pub base_url: Option<String>,
+    /// OpenRouter `HTTP-Referer` attribution header (ignored by other providers)
+    #[serde(default)]
+    pub http_referer: Option<String>,
+    /// OpenRouter `X-Title` attribution header (ignored by other providers)
+    #[serde(default)]
+    pub x_title: Option<String>,
 }
 
 impl AgentConfig {

--- a/a2a-client/examples/sse_streaming_index.html
+++ b/a2a-client/examples/sse_streaming_index.html
@@ -152,6 +152,16 @@
             border-left: 4px solid #1976d2;
         }
 
+        .message.progress {
+            background: #fafafa;
+            border-left: 4px solid #bdbdbd;
+            font-size: 13px;
+        }
+
+        .message.progress .role {
+            color: #9e9e9e;
+        }
+
         .message .role {
             font-weight: 600;
             margin-bottom: 4px;
@@ -221,6 +231,35 @@
         const messageInput = document.getElementById('messageInput');
         const sendBtn = document.getElementById('sendBtn');
 
+        // Streaming state: artifact id -> the .content element accumulating its
+        // chunks, so token-by-token reasoning/answer fill the same bubble.
+        let artifactBubbles = {};
+        let lastAnswerEl = null;
+
+        // Wire format is ProtoJSON: parts are flat `{ "text": "..." }`.
+        const renderParts = (parts) =>
+            (parts || []).map(p => p.text || '').filter(Boolean).join('\n');
+
+        // Append a streamed chunk into the bubble for `artifactId`, creating it on
+        // first sight. "AI Answer" renders as the agent reply; everything else
+        // (e.g. "AI Thinking...") renders as muted progress.
+        function appendArtifact(artifactId, name, text) {
+            clearEmptyState();
+            let contentEl = artifactBubbles[artifactId];
+            if (!contentEl) {
+                const role = name === 'AI Answer' ? 'agent' : 'progress';
+                const div = document.createElement('div');
+                div.className = `message ${role}`;
+                div.innerHTML = `<div class="role">${name}</div><div class="content"></div>`;
+                messagesContainer.appendChild(div);
+                contentEl = div.querySelector('.content');
+                artifactBubbles[artifactId] = contentEl;
+                if (name === 'AI Answer') lastAnswerEl = contentEl;
+            }
+            contentEl.textContent += text;
+            messagesContainer.scrollTop = messagesContainer.scrollHeight;
+        }
+
         function showStatus(message, type = 'info') {
             statusDiv.textContent = message;
             statusDiv.className = `status ${type}`;
@@ -273,33 +312,66 @@
                 const { task_id } = await response.json();
                 showStatus(`Connected to task stream (${task_id})`, 'success');
 
-                // Close existing SSE connection if any
+                // Close existing SSE connection and reset per-task stream state.
                 if (currentEventSource) {
                     currentEventSource.close();
                 }
+                artifactBubbles = {};
+                lastAnswerEl = null;
 
                 // Subscribe to task updates via SSE
                 currentEventSource = new EventSource(`/stream/${task_id}`);
 
+                // Initial snapshot — and, if we subscribed after the task already
+                // completed (no live stream to follow), its final agent message.
                 currentEventSource.addEventListener('task-update', (event) => {
                     const task = JSON.parse(event.data);
-                    if (task.history && task.history.length > 0) {
-                        const lastMessage = task.history[task.history.length - 1];
-                        if (lastMessage.role !== 'User') {
-                            const content = lastMessage.parts
-                                .filter(p => p.Text)
-                                .map(p => p.Text.text)
-                                .join('\n');
-                            if (content) {
-                                addMessage('Agent', content);
-                            }
-                        }
+                    const msg = task.status && task.status.message;
+                    if (msg && msg.role === 'ROLE_AGENT') {
+                        const content = renderParts(msg.parts);
+                        if (content) addMessage('Agent', content);
                     }
                 });
 
+                // Live tokens + progress. "AI Thinking..."/"AI Answer" stream in
+                // token-by-token (accumulated by artifact id); 🛠️/✅ tool steps
+                // arrive as discrete lines.
+                currentEventSource.addEventListener('artifact', (event) => {
+                    const ev = JSON.parse(event.data);
+                    const art = ev.artifact || {};
+                    const text = renderParts(art.parts);
+                    if (!text) return;
+                    if (art.name === 'AI Answer' || art.name === 'AI Thinking...') {
+                        appendArtifact(art.artifactId, art.name, text);
+                    } else {
+                        addMessage('Progress', text);
+                    }
+                });
+
+                // Status transitions. The streamed "AI Answer" bubble already holds
+                // the reply; reconcile it with the authoritative final text (or add
+                // it if nothing streamed, e.g. a non-streaming provider).
                 currentEventSource.addEventListener('task-status', (event) => {
-                    const status = JSON.parse(event.data);
-                    console.log('Task status:', status.state);
+                    const ev = JSON.parse(event.data);
+                    const state = ev.status && ev.status.state;
+                    const msg = ev.status && ev.status.message;
+                    if (msg && msg.role === 'ROLE_AGENT') {
+                        const content = renderParts(msg.parts);
+                        if (content) {
+                            if (lastAnswerEl) lastAnswerEl.textContent = content;
+                            else addMessage('Agent', content);
+                        }
+                    }
+                    if (state === 'TASK_STATE_COMPLETED' || state === 'TASK_STATE_FAILED') {
+                        showStatus(
+                            `Task ${state === 'TASK_STATE_COMPLETED' ? 'completed' : 'failed'}`,
+                            state === 'TASK_STATE_COMPLETED' ? 'success' : 'error'
+                        );
+                        if (currentEventSource) {
+                            currentEventSource.close();
+                            currentEventSource = null;
+                        }
+                    }
                 });
 
                 currentEventSource.onerror = () => {


### PR DESCRIPTION
## Summary

Adds first-class **OpenRouter** support (so models like GLM 5.2 work out of the box), captures and surfaces **reasoning-model output**, and makes the `complex_agent` example **stream tokens live** over SSE. OpenRouter is OpenAI-API-compatible, so it's served by the existing `OpenAiProvider` rather than a new transport.

Verified end to end against `z-ai/glm-5.2` via OpenRouter: provider selection → GLM-driven MCP tool-calling → reasoning capture → token-by-token streaming through the `a2a-web-client` SSE example.

## What's in it

**`a2a-agents-common` — LLM library (`feat(llm)`)**
- `OpenAiConfig`: provider-agnostic `extra_headers` + `openrouter()` / `openrouter_from_env()` constructors (default base URL, optional `HTTP-Referer`/`X-Title` attribution headers).
- New `llm::provider` module: `provider_from_env` (OpenRouter → Gemini → OpenAI, each **key-gated**) and `provider_from_settings(LlmSettings)` for config-driven selection.
- Reasoning capture: `LlmResponse.reasoning` + `LlmStreamEvent::Reasoning`; the OpenAI adapter reads both `reasoning` (OpenRouter-normalized) and `reasoning_content` (raw Zhipu/GLM) on messages and stream deltas.
- Opt-in reasoning request controls: `ReasoningConfig`/`ReasoningEffort` on `LlmRequest`, mapped to OpenRouter's `reasoning` object (sent only when set → plain OpenAI unaffected).

**`a2a-agents` — wiring (`refactor(agents)`)**
- The three duplicated provider-construction sites (`a2a` binary, reimbursement handler, plus env fallback) now go through the shared helper.
- `LlmConfig` gains optional `http_referer`/`x_title`; config path supports `provider = "openrouter"`.
- Restores the no-LLM fallback: the old env cascade always succeeded (defaults to local Ollama), so agents never fell back to their non-LLM path; the key-gated selector returns `None` when nothing is configured.

**`complex_agent` example (`feat(example)`)**
- `process_message` returns `Working` immediately and runs the LLM/tool loop in a spawned task, so SSE subscribers see progress live (a synchronous handler would finish inside the unary `send`).
- `run_with_llm` consumes `chat_completion_stream`: reasoning + answer stream as appending artifacts; tool calls assembled with `ToolCallAccumulator` and run via the MCP bridge between rounds.

**`a2a-web-client` sse example (`fix(client)`)**
- The demo UI never rendered responses: the answer arrives on `task-status` (only logged), parts used the wrong shape (`p.Text.text` vs ProtoJSON `p.text`), and `artifact` events were ignored. Rewrote the handlers to accumulate `AI Thinking…`/`AI Answer` tokens into per-artifact bubbles, render tool steps as progress lines, and reconcile the streamed answer with the authoritative final message.

**`fix(common)`** — unrelated `AgentCache` doctest used the multi-thread tokio flavor without `rt-multi-thread`; switched to `current_thread`.

## Notes
- Transport: the `AgentBuilder` HTTP server serves **ConnectRPC**; the `WebA2AClient` (`http_url`) matches it. (The agent card mislabels the transport as `JSONRPC` — pre-existing, avoid `auto_connect` for now.)
- Pre-1.0 workspace: `LlmResponse`/`LlmStreamEvent`/`LlmRequest` changed and all call sites fixed in this PR; no deprecation shims.
- Changelogs are left to release-plz (conventional commits).

## Test plan
- `cargo clippy --workspace --all-features --all-targets -- -D warnings` — clean
- `cargo test -p a2a-agents-common --all-features` and `cargo test -p a2a-agents --features mcp-server,reimbursement-agent` — pass
- Manual, against OpenRouter GLM:
  ```
  OPENROUTER_API_KEY=... OPENROUTER_MODEL=z-ai/glm-5.2 \
    cargo run -p a2a-agents --example complex_agent --features mcp-server
  cargo run -p a2a-web-client --example sse_streaming   # UI on :3000 -> agent on :8080
  ```
  Observed reasoning + answer streaming token-by-token, tool calls executing, task `COMPLETED`.