### PR TITLE
chore(changelog): repair a2a-ap2 and a2a-mcp changelog corruption

### DIFF
--- a/a2a-ap2/CHANGELOG.md
+++ b/a2a-ap2/CHANGELOG.md
@@ -6,9 +6,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-# Changelog
-
-All notable changes to this project will be documented in this file.
 
 ## [0.3.1](https://github.com/EmilLindfors/a2a-rs/compare/a2a-ap2-v0.3.0...a2a-ap2-v0.3.1) - 2026-06-05
 

--- a/a2a-mcp/CHANGELOG.md
+++ b/a2a-mcp/CHANGELOG.md
@@ -6,9 +6,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-# Changelog
-
-All notable changes to this project will be documented in this file.
 
 ## [0.4.0](https://github.com/EmilLindfors/a2a-rs/compare/a2a-mcp-v0.3.0...a2a-mcp-v0.4.0) - 2026-06-05
 


### PR DESCRIPTION
## What

Removes a stray `# Changelog` + "All notable changes…" block wedged between `## [Unreleased]` and the first version heading in `a2a-ap2/CHANGELOG.md` and `a2a-mcp/CHANGELOG.md`.

## Why

release-plz re-injects its configured header into that malformed spot on every run, which is what kept regenerating an empty "chore: release" PR (#32) whose only diff was more duplicated header lines. Repairing the structure (matching the other crates' changelogs) stops the loop.

a2a-ap2 was repaired once before in #27 and regressed; a2a-mcp carried the same wound. No version/Cargo.toml changes — `chore:` so it triggers no release.

Closes the need for #32 (will close that stale release PR after this merges).